### PR TITLE
Initialize reason and SQLState in PostgresqlServerErrorException.

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlServerErrorException.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlServerErrorException.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.backend.Field.FieldType;
 import io.r2dbc.spi.R2dbcException;
 import reactor.core.publisher.SynchronousSink;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -98,40 +97,30 @@ public final class PostgresqlServerErrorException extends R2dbcException {
      * @throws NullPointerException if {@code fields} is {@code null}
      */
     public PostgresqlServerErrorException(List<Field> fields) {
-        super(tryExtract(fields, MESSAGE), tryExtract(fields, CODE));
-        Objects.requireNonNull(fields, "fields must not be null");
-
-        Map<FieldType, String> map = fields.stream()
-            .collect(Collectors.toMap(Field::getType, Field::getValue));
-
-        this.code = map.get(CODE);
-        this.columnName = map.get(COLUMN_NAME);
-        this.constraintName = map.get(CONSTRAINT_NAME);
-        this.dataTypeName = map.get(DATA_TYPE_NAME);
-        this.detail = map.get(DETAIL);
-        this.file = map.get(FILE);
-        this.hint = map.get(HINT);
-        this.internalPosition = map.get(INTERNAL_POSITION);
-        this.internalQuery = map.get(INTERNAL_QUERY);
-        this.line = map.get(LINE);
-        this.message = map.get(MESSAGE);
-        this.position = map.get(POSITION);
-        this.routine = map.get(ROUTINE);
-        this.schemaName = map.get(SCHEMA_NAME);
-        this.severityLocalized = map.get(SEVERITY_LOCALIZED);
-        this.severityNonLocalized = map.get(SEVERITY_NON_LOCALIZED);
-        this.tableName = map.get(TABLE_NAME);
-        this.where = map.get(WHERE);
+        this(convertToMap(fields));
     }
 
-    @Nullable
-    private static String tryExtract(List<Field> fields, FieldType message) {
+    private PostgresqlServerErrorException(Map<FieldType, String> fields) {
+        super(fields.get(MESSAGE), fields.get(CODE));
 
-        if (fields == null) {
-            return null;
-        }
-
-        return fields.stream().filter(it -> it.getType() == message).map(Field::getValue).findFirst().orElse(null);
+        this.code = fields.get(CODE);
+        this.columnName = fields.get(COLUMN_NAME);
+        this.constraintName = fields.get(CONSTRAINT_NAME);
+        this.dataTypeName = fields.get(DATA_TYPE_NAME);
+        this.detail = fields.get(DETAIL);
+        this.file = fields.get(FILE);
+        this.hint = fields.get(HINT);
+        this.internalPosition = fields.get(INTERNAL_POSITION);
+        this.internalQuery = fields.get(INTERNAL_QUERY);
+        this.line = fields.get(LINE);
+        this.message = fields.get(MESSAGE);
+        this.position = fields.get(POSITION);
+        this.routine = fields.get(ROUTINE);
+        this.schemaName = fields.get(SCHEMA_NAME);
+        this.severityLocalized = fields.get(SEVERITY_LOCALIZED);
+        this.severityNonLocalized = fields.get(SEVERITY_NON_LOCALIZED);
+        this.tableName = fields.get(TABLE_NAME);
+        this.where = fields.get(WHERE);
     }
 
     @Override
@@ -362,6 +351,13 @@ public final class PostgresqlServerErrorException extends R2dbcException {
         } else {
             sink.next(message);
         }
+    }
+
+    private static Map<FieldType, String> convertToMap(List<Field> fields) {
+        Objects.requireNonNull(fields, "fields must not be null");
+
+        return fields.stream()
+            .collect(Collectors.toMap(Field::getType, Field::getValue));
     }
 
     private static PostgresqlServerErrorException toException(ErrorResponse errorResponse) {

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlServerErrorException.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlServerErrorException.java
@@ -23,6 +23,7 @@ import io.r2dbc.postgresql.message.backend.Field.FieldType;
 import io.r2dbc.spi.R2dbcException;
 import reactor.core.publisher.SynchronousSink;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,6 +98,7 @@ public final class PostgresqlServerErrorException extends R2dbcException {
      * @throws NullPointerException if {@code fields} is {@code null}
      */
     public PostgresqlServerErrorException(List<Field> fields) {
+        super(tryExtract(fields, MESSAGE), tryExtract(fields, CODE));
         Objects.requireNonNull(fields, "fields must not be null");
 
         Map<FieldType, String> map = fields.stream()
@@ -120,6 +122,16 @@ public final class PostgresqlServerErrorException extends R2dbcException {
         this.severityNonLocalized = map.get(SEVERITY_NON_LOCALIZED);
         this.tableName = map.get(TABLE_NAME);
         this.where = map.get(WHERE);
+    }
+
+    @Nullable
+    private static String tryExtract(List<Field> fields, FieldType message) {
+
+        if (fields == null) {
+            return null;
+        }
+
+        return fields.stream().filter(it -> it.getType() == message).map(Field::getValue).findFirst().orElse(null);
     }
 
     @Override

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlServerErrorExceptionTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlServerErrorExceptionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.r2dbc.postgresql.message.backend.Field;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class PostgresqlServerErrorExceptionTest {
+
+    @Test
+    void initializesSqlState() {
+
+        List<Field> fields = Collections.singletonList(new Field(Field.FieldType.CODE, "1234"));
+
+        PostgresqlServerErrorException exception = new PostgresqlServerErrorException(fields);
+
+        assertThat(exception.getSqlState()).isEqualTo("1234");
+    }
+
+    @Test
+    void initializesReason() {
+
+        List<Field> fields = Collections.singletonList(new Field(Field.FieldType.MESSAGE, "Duplicate"));
+
+        PostgresqlServerErrorException exception = new PostgresqlServerErrorException(fields);
+
+        assertThat(exception.getMessage()).isEqualTo("Duplicate");
+    }
+
+    @Test
+    void skipsInitializationWithEmptyFields() {
+
+        PostgresqlServerErrorException exception = new PostgresqlServerErrorException(Collections.emptyList());
+
+        assertThat(exception.getSqlState()).isNull();
+        assertThat(exception.getMessage()).isNull();
+    }
+}


### PR DESCRIPTION
We now initialize reason and SQLState properties of R2dbcException
to provide details for code that uses only R2dbcException.
We're aligning the behavior with the JDBC driver that only
populates SQLState and leaves errorCode empty.

Closes gh-3.