### PR TITLE
Reduce Stream Usage

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/message/backend/DataRow.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/DataRow.java
@@ -42,9 +42,11 @@ public final class DataRow implements BackendMessage {
     public DataRow(List<ByteBuf> columns) {
         this.columns = Objects.requireNonNull(columns, "columns must not be null");
 
-        this.columns.stream()
-            .filter(Objects::nonNull)
-            .forEach(ByteBuf::retain);
+        for (ByteBuf column : this.columns) {
+            if (column != null) {
+                column.retain();
+            }
+        }
     }
 
     @Override
@@ -77,9 +79,11 @@ public final class DataRow implements BackendMessage {
      * Release the data encapsulated by the message.
      */
     public void release() {
-        this.columns.stream()
-            .filter(Objects::nonNull)
-            .forEach(ByteBuf::release);
+        for (ByteBuf column : this.columns) {
+            if (column != null) {
+                column.release();
+            }
+        }
     }
 
     @Override

--- a/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.r2dbc.postgresql.message.Format.BINARY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNSPECIFIED;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -53,6 +54,12 @@ final class DefaultCodecsTest {
     }
 
     @Test
+    void decodeNull() {
+        assertThat(new DefaultCodecs(TEST).decode(null, INT4.getObjectId(), BINARY, Integer.class))
+            .isNull();
+    }
+
+    @Test
     void decodeUnsupportedType() {
         assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(TEST).decode(TEST.buffer(4), INT4.getObjectId(), BINARY, Object.class))
             .withMessage("Cannot decode value of type java.lang.Object");
@@ -63,6 +70,13 @@ final class DefaultCodecsTest {
         Parameter parameter = new DefaultCodecs(TEST).encode(100);
 
         assertThat(parameter).isEqualTo(new Parameter(BINARY, INT4.getObjectId(), TEST.buffer(4).writeInt(100)));
+    }
+
+    @Test
+    void encodeNull() {
+        Parameter parameter = new DefaultCodecs(TEST).encode(null);
+
+        assertThat(parameter).isEqualTo(new Parameter(BINARY, UNSPECIFIED.getObjectId(), null));
     }
 
     @Test


### PR DESCRIPTION
Evidence suggests that using the Java 8 Stream API leads to performance decreases and excessive garbage generation.  While this won't matter in most cases, and allowing use of its superior API, high-traffic code should stay away from it.  This change updates the implementation to remove the use of the Stream API in various places where performance and garbage generation will matter significantly.