### PR TITLE
Introduce non-blocking ReactorNettyClient connect method

### DIFF
--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryTest.java
@@ -23,6 +23,7 @@ import io.r2dbc.postgresql.message.backend.AuthenticationOk;
 import io.r2dbc.postgresql.message.frontend.PasswordMessage;
 import io.r2dbc.postgresql.message.frontend.StartupMessage;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
@@ -67,7 +68,7 @@ final class PostgresqlConnectionFactoryTest {
             .password("test-password")
             .build();
 
-        new PostgresqlConnectionFactory(() -> client, configuration)
+        new PostgresqlConnectionFactory(Mono.just(client), configuration)
             .create()
             .as(StepVerifier::create)
             .assertNext(connection -> assertThat(connection.getParameterStatus()).containsEntry("test-key", "test-value"))
@@ -94,7 +95,7 @@ final class PostgresqlConnectionFactoryTest {
             .password("test-password")
             .build();
 
-        assertThat(new PostgresqlConnectionFactory(() -> client, configuration).getMetadata()).isNotNull();
+        assertThat(new PostgresqlConnectionFactory(Mono.just(client), configuration).getMetadata()).isNotNull();
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientTest.java
+++ b/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientTest.java
@@ -45,7 +45,7 @@ final class ReactorNettyClientTest {
     @RegisterExtension
     static final PostgresqlServerExtension SERVER = new PostgresqlServerExtension();
 
-    private final ReactorNettyClient client = new ReactorNettyClient(SERVER.getHost(), SERVER.getPort());
+    private final ReactorNettyClient client = ReactorNettyClient.connect(SERVER.getHost(), SERVER.getPort()).block();
 
     @Test
     void close() {
@@ -63,7 +63,7 @@ final class ReactorNettyClientTest {
 
     @Test
     void constructorNoHost() {
-        assertThatNullPointerException().isThrownBy(() -> new ReactorNettyClient(null, SERVER.getPort()))
+        assertThatNullPointerException().isThrownBy(() -> ReactorNettyClient.connect(null, SERVER.getPort()))
             .withMessage("host must not be null");
     }
 


### PR DESCRIPTION
ReactorNettyClient now exposes a factory method returning
Mono<ReactorNettyClient> to not block on connect.
New connection requests yield in creating a new connection
and do not use a connection pool.

[resolves #10]