### PR TITLE
Add additional decoding for TEXT, CHAR, AND UNKNOWN

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/client/Binding.java
+++ b/src/main/java/io/r2dbc/postgresql/client/Binding.java
@@ -28,14 +28,14 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static io.r2dbc.postgresql.message.Format.TEXT;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNSPECIFIED;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNKNOWN;
 
 /**
  * A collection of {@link Parameter}s for a single bind invocation of an {@link ExtendedQueryMessageFlow}.
  */
 public final class Binding {
 
-    private static final Parameter UNSPECIFIED_PARAMETER = new Parameter(TEXT, UNSPECIFIED.getObjectId(), null);
+    private static final Parameter UNKNOWN_PARAMETER = new Parameter(TEXT, UNKNOWN.getObjectId(), null);
 
     private final SortedMap<Integer, Parameter> parameters = new TreeMap<>();
 
@@ -114,7 +114,7 @@ public final class Binding {
     }
 
     private Parameter get(Integer identifier) {
-        return this.parameters.getOrDefault(identifier, UNSPECIFIED_PARAMETER);
+        return this.parameters.getOrDefault(identifier, UNKNOWN_PARAMETER);
     }
 
     private Stream<Parameter> getParameters() {

--- a/src/main/java/io/r2dbc/postgresql/codec/InetAddressCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/InetAddressCodec.java
@@ -29,7 +29,7 @@ import java.net.UnknownHostException;
 import java.util.Objects;
 
 import static io.r2dbc.postgresql.message.Format.TEXT;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNSPECIFIED;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNKNOWN;
 
 final class InetAddressCodec extends AbstractCodec<InetAddress> {
 
@@ -42,7 +42,7 @@ final class InetAddressCodec extends AbstractCodec<InetAddress> {
 
     @Override
     public Parameter encodeNull() {
-        return createNull(TEXT, UNSPECIFIED);
+        return createNull(TEXT, UNKNOWN);
     }
 
     @Override
@@ -50,7 +50,7 @@ final class InetAddressCodec extends AbstractCodec<InetAddress> {
         Objects.requireNonNull(format, "format must not be null");
         Objects.requireNonNull(type, "type must not be null");
 
-        return TEXT == format && UNSPECIFIED == type;
+        return TEXT == format && UNKNOWN == type;
     }
 
     @Override
@@ -69,7 +69,7 @@ final class InetAddressCodec extends AbstractCodec<InetAddress> {
         Objects.requireNonNull(value, "value must not be null");
 
         ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.getHostAddress());
-        return create(TEXT, UNSPECIFIED, encoded);
+        return create(TEXT, UNKNOWN, encoded);
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/StringCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/StringCodec.java
@@ -27,6 +27,8 @@ import reactor.util.annotation.Nullable;
 import java.util.Objects;
 
 import static io.r2dbc.postgresql.message.Format.TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.CHAR;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNKNOWN;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
 
 final class StringCodec extends AbstractCodec<String> {
@@ -48,7 +50,7 @@ final class StringCodec extends AbstractCodec<String> {
         Objects.requireNonNull(format, "format must not be null");
         Objects.requireNonNull(type, "type must not be null");
 
-        return TEXT == format && VARCHAR == type;
+        return Format.TEXT == format && (UNKNOWN == type || VARCHAR == type || PostgresqlObjectId.TEXT == type || CHAR ==type );
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/type/PostgresqlObjectId.java
+++ b/src/main/java/io/r2dbc/postgresql/type/PostgresqlObjectId.java
@@ -274,9 +274,9 @@ public enum PostgresqlObjectId {
     TIMETZ_ARRAY(1270),
 
     /**
-     * The unspecified object id.
+     * The unknown object id.
      */
-    UNSPECIFIED(2),
+    UNKNOWN(705),
 
     /**
      * The UUID object id.

--- a/src/test/java/io/r2dbc/postgresql/client/BindingTest.java
+++ b/src/test/java/io/r2dbc/postgresql/client/BindingTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.r2dbc.postgresql.message.Format.BINARY;
 import static io.r2dbc.postgresql.message.Format.TEXT;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNSPECIFIED;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNKNOWN;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -61,7 +61,7 @@ final class BindingTest {
         binding.add(0, new Parameter(BINARY, 100, TEST.buffer(4).writeInt(200)));
         binding.add(2, new Parameter(BINARY, 100, TEST.buffer(4).writeInt(300)));
 
-        assertThat(binding.getParameterTypes()).containsExactly(100, UNSPECIFIED.getObjectId(), 100);
+        assertThat(binding.getParameterTypes()).containsExactly(100, UNKNOWN.getObjectId(), 100);
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/InetAddressCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/InetAddressCodecTest.java
@@ -25,7 +25,7 @@ import java.net.UnknownHostException;
 import static io.r2dbc.postgresql.message.Format.BINARY;
 import static io.r2dbc.postgresql.message.Format.TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.MONEY;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNSPECIFIED;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNKNOWN;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
 import static io.r2dbc.postgresql.util.ByteBufUtils.encode;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
@@ -57,9 +57,9 @@ final class InetAddressCodecTest {
     void doCanDecode() {
         InetAddressCodec codec = new InetAddressCodec(TEST);
 
-        assertThat(codec.doCanDecode(BINARY, UNSPECIFIED)).isFalse();
+        assertThat(codec.doCanDecode(BINARY, UNKNOWN)).isFalse();
         assertThat(codec.doCanDecode(TEXT, MONEY)).isFalse();
-        assertThat(codec.doCanDecode(TEXT, UNSPECIFIED)).isTrue();
+        assertThat(codec.doCanDecode(TEXT, UNKNOWN)).isTrue();
     }
 
     @Test
@@ -79,7 +79,7 @@ final class InetAddressCodecTest {
         InetAddress inetAddress = InetAddress.getByName("localhost");
 
         assertThat(new InetAddressCodec(TEST).doEncode(inetAddress))
-            .isEqualTo(new Parameter(TEXT, UNSPECIFIED.getObjectId(), encode(TEST, inetAddress.getHostAddress())));
+            .isEqualTo(new Parameter(TEXT, UNKNOWN.getObjectId(), encode(TEST, inetAddress.getHostAddress())));
     }
 
     @Test
@@ -91,7 +91,7 @@ final class InetAddressCodecTest {
     @Test
     void encodeNull() {
         assertThat(new InetAddressCodec(TEST).encodeNull())
-            .isEqualTo(new Parameter(TEXT, UNSPECIFIED.getObjectId(), null));
+            .isEqualTo(new Parameter(TEXT, UNKNOWN.getObjectId(), null));
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/codec/StringCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/StringCodecTest.java
@@ -17,11 +17,14 @@
 package io.r2dbc.postgresql.codec;
 
 import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import org.junit.jupiter.api.Test;
 
 import static io.r2dbc.postgresql.message.Format.BINARY;
 import static io.r2dbc.postgresql.message.Format.TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.CHAR;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.MONEY;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNKNOWN;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
 import static io.r2dbc.postgresql.util.ByteBufUtils.encode;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
@@ -52,8 +55,13 @@ final class StringCodecTest {
         StringCodec codec = new StringCodec(TEST);
 
         assertThat(codec.doCanDecode(BINARY, VARCHAR)).isFalse();
+        // money is deprecated but we may want to actually decode this
         assertThat(codec.doCanDecode(TEXT, MONEY)).isFalse();
         assertThat(codec.doCanDecode(TEXT, VARCHAR)).isTrue();
+        assertThat(codec.doCanDecode(TEXT, PostgresqlObjectId.TEXT)).isTrue();
+        assertThat(codec.doCanDecode(TEXT, CHAR)).isTrue();
+        assertThat(codec.doCanDecode(TEXT, UNKNOWN)).isTrue();
+
     }
 
     @Test


### PR DESCRIPTION
Removed UNSPECIFIED type, replace with UNKNOWN
Pretty sure there is no type or class in postgresql where the oid is 2
UNKNOWN is a real possibility though, and in my opinion a better default.