### PR TITLE
Covered all textual values for Boolean

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/BooleanCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BooleanCodec.java
@@ -55,7 +55,10 @@ final class BooleanCodec extends AbstractCodec<Boolean> {
     Boolean doDecode(ByteBuf byteBuf, @Nullable Format format, @Nullable Class<? extends Boolean> type) {
         Objects.requireNonNull(byteBuf, "byteBuf must not be null");
 
-        return Boolean.valueOf(ByteBufUtils.decode(byteBuf));
+        String decoded = ByteBufUtils.decode(byteBuf);
+        return "1".equals(decoded) || "true".equalsIgnoreCase(decoded)
+                || "t".equalsIgnoreCase(decoded) || "yes".equalsIgnoreCase(decoded)
+                || "y".equalsIgnoreCase(decoded) || "on".equalsIgnoreCase(decoded);
     }
 
     @Override

--- a/src/test/java/io/r2dbc/postgresql/codec/BooleanCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/BooleanCodecTest.java
@@ -19,6 +19,8 @@ package io.r2dbc.postgresql.codec;
 import io.r2dbc.postgresql.client.Parameter;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static io.r2dbc.postgresql.message.Format.BINARY;
 import static io.r2dbc.postgresql.message.Format.TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.BOOL;
@@ -41,8 +43,10 @@ final class BooleanCodecTest {
     void decode() {
         BooleanCodec codec = new BooleanCodec(TEST);
 
-        assertThat(codec.decode(encode(TEST, "TRUE"), TEXT, Boolean.class)).isTrue();
-        assertThat(codec.decode(encode(TEST, "FALSE"), TEXT, Boolean.class)).isFalse();
+        Arrays.asList("1", "True", "T", "Yes", "Y", "On")
+                .forEach(input -> assertThat(codec.decode(encode(TEST, input), TEXT, Boolean.class)).isTrue());
+        Arrays.asList("0", "False", "F", "No", "N", "Off")
+                .forEach(input -> assertThat(codec.decode(encode(TEST, input), TEXT, Boolean.class)).isFalse());
     }
 
     @Test


### PR DESCRIPTION
Hi, I have noticed that boolean flags are incorrectly decoded in current version, because PostgreSQL in TEXT mode uses few different strings for boolean states. My db in version 10.5 had t/f in place of expected TRUE/FALSE so mapped entity always has got false value.
I covered all possible values which are included in original encoder:
https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/BooleanTypeUtil.java

Best regards :)
