### PR TITLE
fixes memory leak in BackendMessageDecoder

### DIFF
--- a/src/test/java/io/r2dbc/postgresql/message/backend/BackendMessageDecoderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/message/backend/BackendMessageDecoderTest.java
@@ -17,6 +17,7 @@
 package io.r2dbc.postgresql.message.backend;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -384,7 +385,7 @@ final class BackendMessageDecoderTest {
                     .writeBytes(payload))
             .reduce(TEST.buffer(), ByteBuf::writeBytes);
 
-        BackendMessageDecoder decoder = new BackendMessageDecoder();
+        BackendMessageDecoder decoder = new BackendMessageDecoder(UnpooledByteBufAllocator.DEFAULT);
 
         return Flux.just(data.readRetainedSlice(data.readableBytes() / 2), data)
             .concatMap(decoder::decode)


### PR DESCRIPTION
Pull request to address the issue mentioned in #48 

Switches from an AtomicReference with a ByteBuf to a CompositeByteBuf and uses discardReadComponents to remove read data. Also the in the ReactorNettyClient there were two separate Publishers that could error out could leave one of them in a bad state. The Publishers are merged and when either side receives an error it will tear down and clean up after themselves. 

