### PR TITLE
Added support for listening to notifications

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
@@ -21,15 +21,18 @@ import io.r2dbc.postgresql.client.PortalNameSupplier;
 import io.r2dbc.postgresql.client.SimpleQueryMessageFlow;
 import io.r2dbc.postgresql.client.TransactionStatus;
 import io.r2dbc.postgresql.codec.Codecs;
+import io.r2dbc.postgresql.message.backend.NotificationResponse;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.IsolationLevel;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static io.r2dbc.postgresql.client.TransactionStatus.IDLE;
@@ -163,6 +166,12 @@ public final class PostgresqlConnection implements Connection {
                 return Mono.empty();
             }
         });
+    }
+
+    public Disposable addNotificationListener(Consumer<NotificationResponse> consumer) {
+        Assert.requireNonNull(consumer, "consumer must not be null");
+
+        return this.client.addNotificationListener(consumer);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/client/Client.java
+++ b/src/main/java/io/r2dbc/postgresql/client/Client.java
@@ -18,13 +18,16 @@ package io.r2dbc.postgresql.client;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.r2dbc.postgresql.message.backend.BackendMessage;
+import io.r2dbc.postgresql.message.backend.NotificationResponse;
 import io.r2dbc.postgresql.message.backend.ReadyForQuery;
 import io.r2dbc.postgresql.message.frontend.FrontendMessage;
 import org.reactivestreams.Publisher;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * An abstraction that wraps the networking part of exchanging methods.
@@ -75,4 +78,12 @@ public interface Client {
      */
     TransactionStatus getTransactionStatus();
 
+    /**
+     * Add a consumer of notification messages.
+     *
+     * @param consumer the consumer of notification messages
+     * @return a new {@link Disposable} that can be used to cancel the underlying subscription.
+     * @throws IllegalArgumentException if {@code consumer} is {@code null}
+     */
+    Disposable addNotificationListener(Consumer<NotificationResponse> consumer);
 }

--- a/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
@@ -25,6 +25,7 @@ import io.r2dbc.postgresql.message.backend.BackendMessageDecoder;
 import io.r2dbc.postgresql.message.backend.ErrorResponse;
 import io.r2dbc.postgresql.message.backend.Field;
 import io.r2dbc.postgresql.message.backend.NoticeResponse;
+import io.r2dbc.postgresql.message.backend.NotificationResponse;
 import io.r2dbc.postgresql.message.backend.ReadyForQuery;
 import io.r2dbc.postgresql.message.frontend.FrontendMessage;
 import io.r2dbc.postgresql.message.frontend.Terminate;
@@ -32,6 +33,7 @@ import io.r2dbc.postgresql.util.Assert;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
@@ -50,6 +52,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -104,6 +107,11 @@ public final class ReactorNettyClient implements Client {
             sink.next(message);
         });
 
+    private final EmitterProcessor<NotificationResponse> notificationProcessor = EmitterProcessor.create(false);
+
+    private final BiConsumer<BackendMessage, SynchronousSink<BackendMessage>> handleNotificationResponse = handleBackendMessage(NotificationResponse.class,
+        (message, sink) -> this.notificationProcessor.onNext(message));
+
     /**
      * Creates a new frame processor connected to a given TCP connection.
      *
@@ -124,6 +132,7 @@ public final class ReactorNettyClient implements Client {
             .concatMap(decoder::decode)
             .doOnNext(message -> this.logger.debug("Response: {}", message))
             .handle(this.handleNoticeResponse)
+            .handle(this.handleNotificationResponse)
             .handle(this.handleErrorResponse)
             .handle(this.handleBackendKeyData)
             .handle(this.handleReadyForQuery)
@@ -256,6 +265,11 @@ public final class ReactorNettyClient implements Client {
     @Override
     public TransactionStatus getTransactionStatus() {
         return this.transactionStatus.get();
+    }
+
+    @Override
+    public Disposable addNotificationListener(Consumer<NotificationResponse> consumer) {
+        return this.notificationProcessor.subscribe(consumer);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
It seems there is very little in the way of exposing Postgres asynchronous notifications (https://www.postgresql.org/docs/9.3/libpq-notify.html) via the client. This allows a consumer to be configured which is called each time a NotificationResponse is received. This allows r2dbc users to take advantage of basic pub/sub functionality via the Postgres LISTEN/NOTIFY mechanism (see tests for examples).

In terms of the API I'm not sure whether a Consumer is preferable or if it would be better to expose a Flux<NotificationResponse> directly.