### PR TITLE
Accept multidimensional array as parameter type in array codecs

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
@@ -36,12 +36,16 @@ abstract class AbstractCodec<T> implements Codec<T> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return type.isAssignableFrom(this.type) &&
+        return isTypeAssignable(type) &&
             doCanDecode(format, PostgresqlObjectId.valueOf(dataType));
     }
 
+    boolean isTypeAssignable(Class<?> type) {
+        return type.isAssignableFrom(this.type);
+    }
+
     @Override
-    public final boolean canEncode(Object value) {
+    public boolean canEncode(Object value) {
         Assert.requireNonNull(value, "value must not be null");
 
         return this.type.isInstance(value);

--- a/src/main/java/io/r2dbc/postgresql/codec/IntegerArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/IntegerArrayCodec.java
@@ -33,7 +33,7 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4_ARRAY;
 final class IntegerArrayCodec extends AbstractArrayCodec<Integer> {
 
     IntegerArrayCodec(ByteBufAllocator byteBufAllocator) {
-        super(byteBufAllocator, Integer[].class);
+        super(byteBufAllocator, Integer.class);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/LongArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/LongArrayCodec.java
@@ -33,7 +33,7 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT8_ARRAY;
 final class LongArrayCodec extends AbstractArrayCodec<Long> {
 
     LongArrayCodec(ByteBufAllocator byteBufAllocator) {
-        super(byteBufAllocator, Long[].class);
+        super(byteBufAllocator, Long.class);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/ShortArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ShortArrayCodec.java
@@ -33,7 +33,7 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2_ARRAY;
 final class ShortArrayCodec extends AbstractArrayCodec<Short> {
 
     ShortArrayCodec(ByteBufAllocator byteBufAllocator) {
-        super(byteBufAllocator, Short[].class);
+        super(byteBufAllocator, Short.class);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/StringArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/StringArrayCodec.java
@@ -35,7 +35,7 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR_ARRAY;
 final class StringArrayCodec extends AbstractArrayCodec<String> {
 
     StringArrayCodec(ByteBufAllocator byteBufAllocator) {
-        super(byteBufAllocator, String[].class);
+        super(byteBufAllocator, String.class);
     }
 
     @Override

--- a/src/test/java/io/r2dbc/postgresql/codec/IntegerArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/IntegerArrayCodecTest.java
@@ -28,6 +28,7 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4_ARRAY;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final class IntegerArrayCodecTest {
 
@@ -105,4 +106,13 @@ final class IntegerArrayCodecTest {
             .isEqualTo(new Parameter(FORMAT_TEXT, INT4_ARRAY.getObjectId(), null));
     }
 
+    @Test
+    void multidimensionalArrayNotYetAllowed() {
+        IntegerArrayCodec codec = new IntegerArrayCodec(TEST);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> codec.decode(ByteBufUtils.encode(TEST, "{{100},{200}}"), FORMAT_TEXT, Integer[][].class)
+        );
+    }
 }


### PR DESCRIPTION
Implementation of multidimensional arrays (#42) are split into 2 parts:
- support multidimensional java array as type parameter and additional type validation (this PR)
- implementations of `doEncode`, `doEncodeItem`, `doDecode`, `doDecodeItem`

I think doing it as a single PR would be too big for review.