### PR TITLE
postgresql multidimensional array implementation

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractArrayCodec.java
@@ -23,14 +23,19 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.util.Assert;
 
 import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 
 abstract class AbstractArrayCodec<T> extends AbstractCodec<Object[]> {
 
-    private static final byte DELIMITER = ',';
+    private static final String NULL = "NULL";
+    private static final byte[] COMMA = ",".getBytes();
+    private static final byte[] OPEN_CURLY = "{".getBytes();
+    private static final byte[] CLOSE_CURLY = "}".getBytes();
 
     private final ByteBufAllocator byteBufAllocator;
 
@@ -49,62 +54,36 @@ abstract class AbstractArrayCodec<T> extends AbstractCodec<Object[]> {
         return isTypeAssignable(value.getClass());
     }
 
-    abstract T decodeItem(ByteBuf byteBuf, Format format, Class<?> type);
+    abstract T decodeItem(ByteBuf byteBuf);
+
+    abstract T decodeItem(String strValue);
 
     @Override
     final Object[] doDecode(ByteBuf byteBuf, Format format, Class<? extends Object[]> type) {
         Assert.requireNonNull(byteBuf, "byteBuf must not be null");
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
-        Assert.requireArrayDimension(type, 1, "type must be an array with one dimension");
-
-        List<T> items = new ArrayList<>();
 
         if (FORMAT_BINARY == format) {
-            while (byteBuf.readableBytes() != 0) {
-                items.add(decodeItem(byteBuf, format, type));
-            }
+            return decodeBinary(byteBuf, type);
         } else {
-            byteBuf.skipBytes(1);
-
-            for (int size = byteBuf.bytesBefore(DELIMITER); size != -1; size = byteBuf.bytesBefore(DELIMITER)) {
-                items.add(decodeItem(byteBuf.readSlice(size), format, type.getComponentType()));
-                byteBuf.skipBytes(1); // skip delimiter
-            }
-
-            items.add(decodeItem(byteBuf.readSlice(byteBuf.readableBytes() - 1), format, this.componentType));
+            return decodeText(byteBuf, type);
         }
-
-        Object[] a = (Object[]) Array.newInstance(this.componentType, items.size());
-        return items.toArray(a);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     final Parameter doEncode(Object[] value) {
         Assert.requireNonNull(value, "value must not be null");
-        Assert.requireArrayDimension(value.getClass(), 1, "value must be an array with one dimension");
 
         ByteBuf byteBuf = this.byteBufAllocator.buffer();
-        byteBuf.writeByte('{');
-
-        if (value.length > 0) {
-            encodeItem(byteBuf, (T) value[0]);
-
-            for (int i = 1; i < value.length; i++) {
-                byteBuf.writeByte(DELIMITER);
-                encodeItem(byteBuf, (T) value[i]);
-            }
-        }
-
-        byteBuf.writeByte('}');
+        encodeAsText(byteBuf, value, this::encodeItem);
 
         return encodeArray(byteBuf);
     }
 
     abstract Parameter encodeArray(ByteBuf byteBuf);
 
-    abstract void encodeItem(ByteBuf byteBuf, T value);
+    abstract String encodeItem(T value);
 
     boolean isTypeAssignable(Class<?> type) {
         Assert.requireNonNull(type, "type must not be null");
@@ -116,6 +95,21 @@ abstract class AbstractArrayCodec<T> extends AbstractCodec<Object[]> {
         return getBaseComponentType(type).equals(this.componentType);
     }
 
+    static String escapeArrayElement(String s) {
+        StringBuilder b = new StringBuilder();
+        b.append('"');
+        for (int j = 0; j < s.length(); j++) {
+            char c = s.charAt(j);
+            if (c == '"' || c == '\\') {
+                b.append('\\');
+            }
+
+            b.append(c);
+        }
+        b.append('"');
+        return b.toString();
+    }
+
     private static Class<?> getBaseComponentType(Class<?> type) {
         Class<?> t = type;
 
@@ -124,5 +118,212 @@ abstract class AbstractArrayCodec<T> extends AbstractCodec<Object[]> {
         }
 
         return t;
+    }
+
+    private static int getDimensions(List<?> list) {
+        int dims = 1;
+
+        Object inner = list.get(0);
+
+        while (inner instanceof List) {
+            inner = ((List) inner).get(0);
+            dims++;
+        }
+
+        return dims;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void encodeAsText(ByteBuf byteBuf, Object[] value, Function<T, String> encoder) {
+        byteBuf.writeBytes(OPEN_CURLY);
+        for (int i = 0; i < value.length; i++) {
+            Object item = value[i];
+            if (item instanceof Object[]) {
+                encodeAsText(byteBuf, (Object[]) item, encoder);
+            } else {
+                byteBuf.writeCharSequence(item == null ? NULL : encoder.apply((T) item), StandardCharsets.UTF_8);
+            }
+
+            if (i != value.length - 1) {
+                byteBuf.writeBytes(COMMA);
+            }
+        }
+        byteBuf.writeBytes(CLOSE_CURLY);
+    }
+
+    private void readArrayAsBinary(ByteBuf buffer, Object[] array, int[] dims, int thisDimension) {
+        if (thisDimension == dims.length - 1) {
+            for (int i = 0; i < dims[thisDimension]; ++i) {
+                int len = buffer.readInt();
+                if (len == -1) {
+                    continue;
+
+                }
+                array[i] = decodeItem(buffer.readBytes(len));
+            }
+        } else {
+            for (int i = 0; i < dims[thisDimension]; ++i) {
+                array[i] = createArray(array.getClass().getComponentType(), dims[thisDimension + 1]);
+                readArrayAsBinary(buffer, (Object[]) array[i], dims, thisDimension + 1);
+            }
+        }
+    }
+
+    private Object[] decodeBinary(ByteBuf buffer, Class<? extends Object[]> returnType) {
+        int dimensions = buffer.readInt();
+        if (dimensions == 0) {
+            return createArray(returnType, 0);
+        }
+        Assert.requireArrayDimension(returnType, dimensions, "Dimensions mismatch: %s expected, but %s returned from DB");
+
+        buffer.skipBytes(4); // flags: 0=no-nulls, 1=has-nulls
+        buffer.skipBytes(4); // element oid
+
+        int[] dims = new int[dimensions];
+        for (int d = 0; d < dimensions; ++d) {
+            dims[d] = buffer.readInt(); // dimension size
+            buffer.skipBytes(4); // lower bound ignored
+        }
+
+        Object[] array = createArray(returnType, dims[0]);
+
+        readArrayAsBinary(buffer, array, dims, 0);
+
+        return array;
+    }
+
+    private Object[] decodeText(ByteBuf buffer, Class<? extends Object[]> returnType) {
+        List<?> elements = buildArrayList(buffer);
+
+        if (elements.isEmpty()) {
+            return toArray(elements, returnType.getComponentType());
+        }
+
+        Assert.requireArrayDimension(returnType, getDimensions(elements), "Dimensions mismatch: %s expected, but %s returned from DB");
+
+        return toArray(elements, returnType.getComponentType());
+    }
+
+    private Object[] createArray(Class<?> returnType, int size) {
+        return (Object[]) Array.newInstance(returnType.getComponentType(), size);
+    }
+
+    private static Object[] toArray(List<?> list, Class<?> returnType) {
+        return list
+                .stream()
+                .map(e -> (e instanceof List ? toArray((List) e, returnType.getComponentType()) : e))
+                .toArray(r ->  (Object[]) Array.newInstance(returnType, list.size()));
+    }
+
+    private List<Object> buildArrayList(ByteBuf buf) {
+        List<Object> arrayList = new ArrayList<>();
+
+        char delim = ','; // todo parametrize
+
+        StringBuilder buffer = null;
+        boolean insideString = false;
+        boolean wasInsideString = false; // needed for checking if NULL
+        // value occurred
+        List<List<Object>> dims = new ArrayList<>(); // array dimension arrays
+        List<Object> curArray = arrayList; // currently processed array
+
+        CharSequence chars = buf.readCharSequence(buf.readableBytes(), StandardCharsets.UTF_8);
+
+        // Starting with 8.0 non-standard (beginning index
+        // isn't 1) bounds the dimensions are returned in the
+        // data formatted like so "[0:3]={0,1,2,3,4}".
+        // Older versions simply do not return the bounds.
+        //
+        // Right now we ignore these bounds, but we could
+        // consider allowing these index values to be used
+        // even though the JDBC spec says 1 is the first
+        // index. I'm not sure what a client would like
+        // to see, so we just retain the old behavior.
+        int startOffset = 0;
+
+        {
+            if (chars.charAt(0) == '[') {
+                while (chars.charAt(startOffset) != '=') {
+                    startOffset++;
+                }
+                startOffset++; // skip =
+            }
+        }
+
+        char currentChar;
+
+        for (int i = startOffset; i < chars.length(); i++) {
+            currentChar = chars.charAt(i);
+            // escape character that we need to skip
+            if (currentChar == '\\') {
+                i++;
+                currentChar = chars.charAt(i);
+            } else if (!insideString && currentChar == '{') {
+                // subarray start
+                if (dims.isEmpty()) {
+                    dims.add(arrayList);
+                } else {
+                    List<Object> a = new ArrayList<>();
+                    List<Object> p = dims.get(dims.size() - 1);
+                    p.add(a);
+                    dims.add(a);
+                }
+                curArray = dims.get(dims.size() - 1);
+
+                for (int t = i + 1; t < chars.length(); t++) {
+                    if (!Character.isWhitespace(chars.charAt(t)) && chars.charAt(t) != '{') {
+                        break;
+                    }
+                }
+
+                buffer = new StringBuilder();
+                continue;
+            } else if (currentChar == '"') {
+                // quoted element
+                insideString = !insideString;
+                wasInsideString = true;
+                continue;
+            } else if (!insideString && Character.isWhitespace(currentChar)) {
+                // white space
+                continue;
+            } else if ((!insideString && (currentChar == delim || currentChar == '}'))
+                    || i == chars.length() - 1) {
+                // array end or element end
+                // when character that is a part of array element
+                if (currentChar != '"' && currentChar != '}' && currentChar != delim && buffer != null) {
+                    buffer.append(currentChar);
+                }
+
+                String b = buffer == null ? null : buffer.toString();
+
+                // add element to current array
+                if (b != null && (!b.isEmpty() || wasInsideString)) {
+                    curArray.add(!wasInsideString && b.equals("NULL") ? null : decodeItem(b));
+                }
+
+                wasInsideString = false;
+                buffer = new StringBuilder();
+
+                // when end of an array
+                if (currentChar == '}') {
+                    dims.remove(dims.size() - 1);
+
+                    // when multi-dimension
+                    if (!dims.isEmpty()) {
+                        curArray = dims.get(dims.size() - 1);
+                    }
+
+                    buffer = null;
+                }
+
+                continue;
+            }
+
+            if (buffer != null) {
+                buffer.append(currentChar);
+            }
+        }
+
+        return arrayList;
     }
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
@@ -36,7 +36,7 @@ abstract class AbstractCodec<T> implements Codec<T> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return isTypeAssignable(type) &&
+        return (type == Object.class || isTypeAssignable(type)) &&
             doCanDecode(format, PostgresqlObjectId.valueOf(dataType));
     }
 

--- a/src/main/java/io/r2dbc/postgresql/codec/IntegerArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/IntegerArrayCodec.java
@@ -18,15 +18,11 @@ package io.r2dbc.postgresql.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufUtil;
 import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.util.annotation.Nullable;
 
-import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4_ARRAY;
 
@@ -37,15 +33,13 @@ final class IntegerArrayCodec extends AbstractArrayCodec<Integer> {
     }
 
     @Override
-    public Integer decodeItem(ByteBuf byteBuf, Format format, @Nullable Class<?> type) {
-        Assert.requireNonNull(byteBuf, "byteBuf must not be null");
-        Assert.requireNonNull(format, "format must not be null");
+    Integer decodeItem(ByteBuf byteBuf) {
+        return byteBuf.readInt();
+    }
 
-        if (FORMAT_BINARY == format) {
-            return byteBuf.readInt();
-        } else {
-            return Integer.parseInt(ByteBufUtils.decode(byteBuf));
-        }
+    @Override
+    Integer decodeItem(String strValue) {
+        return Integer.parseInt(strValue);
     }
 
     @Override
@@ -68,11 +62,9 @@ final class IntegerArrayCodec extends AbstractArrayCodec<Integer> {
     }
 
     @Override
-    void encodeItem(ByteBuf byteBuf, Integer value) {
-        Assert.requireNonNull(byteBuf, "byteBuf must not be null");
+    String encodeItem(Integer value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBufUtil.writeUtf8(byteBuf, value.toString());
+        return value.toString();
     }
-
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/LongArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/LongArrayCodec.java
@@ -18,15 +18,11 @@ package io.r2dbc.postgresql.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufUtil;
 import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.util.annotation.Nullable;
 
-import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT8_ARRAY;
 
@@ -37,15 +33,13 @@ final class LongArrayCodec extends AbstractArrayCodec<Long> {
     }
 
     @Override
-    public Long decodeItem(ByteBuf byteBuf, Format format, @Nullable Class<?> type) {
-        Assert.requireNonNull(byteBuf, "byteBuf must not be null");
-        Assert.requireNonNull(format, "format must not be null");
+    Long decodeItem(ByteBuf byteBuf) {
+        return byteBuf.readLong();
+    }
 
-        if (FORMAT_BINARY == format) {
-            return byteBuf.readLong();
-        } else {
-            return Long.parseLong(ByteBufUtils.decode(byteBuf));
-        }
+    @Override
+    Long decodeItem(String strValue) {
+        return Long.parseLong(strValue);
     }
 
     @Override
@@ -68,11 +62,10 @@ final class LongArrayCodec extends AbstractArrayCodec<Long> {
     }
 
     @Override
-    void encodeItem(ByteBuf byteBuf, Long value) {
-        Assert.requireNonNull(byteBuf, "byteBuf must not be null");
+    String encodeItem(Long value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBufUtil.writeUtf8(byteBuf, value.toString());
+        return value.toString();
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/ShortArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ShortArrayCodec.java
@@ -18,15 +18,12 @@ package io.r2dbc.postgresql.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufUtil;
 import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
-import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2_ARRAY;
 
@@ -37,15 +34,13 @@ final class ShortArrayCodec extends AbstractArrayCodec<Short> {
     }
 
     @Override
-    public Short decodeItem(ByteBuf byteBuf, Format format, @Nullable Class<?> type) {
-        Assert.requireNonNull(byteBuf, "byteBuf must not be null");
-        Assert.requireNonNull(format, "format must not be null");
+    Short decodeItem(ByteBuf byteBuf) {
+        return byteBuf.readShort();
+    }
 
-        if (FORMAT_BINARY == format) {
-            return byteBuf.readShort();
-        } else {
-            return Short.parseShort(ByteBufUtils.decode(byteBuf));
-        }
+    @Override
+    Short decodeItem(String strValue) {
+        return Short.parseShort(strValue);
     }
 
     @Override
@@ -68,11 +63,10 @@ final class ShortArrayCodec extends AbstractArrayCodec<Short> {
     }
 
     @Override
-    void encodeItem(ByteBuf byteBuf, Short value) {
-        Assert.requireNonNull(byteBuf, "byteBuf must not be null");
+    String encodeItem(Short value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBufUtil.writeUtf8(byteBuf, value.toString());
+        return value.toString();
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/StringArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/StringArrayCodec.java
@@ -18,12 +18,10 @@ package io.r2dbc.postgresql.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufUtil;
 import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import reactor.util.annotation.Nullable;
 
 import static io.netty.util.CharsetUtil.UTF_8;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -39,10 +37,13 @@ final class StringArrayCodec extends AbstractArrayCodec<String> {
     }
 
     @Override
-    public String decodeItem(ByteBuf byteBuf, @Nullable Format format, @Nullable Class<?> type) {
-        Assert.requireNonNull(byteBuf, "byteBuf must not be null");
-
+    String decodeItem(ByteBuf byteBuf) {
         return byteBuf.toString(UTF_8);
+    }
+
+    @Override
+    String decodeItem(String strValue) {
+        return strValue;
     }
 
     @Override
@@ -66,11 +67,10 @@ final class StringArrayCodec extends AbstractArrayCodec<String> {
     }
 
     @Override
-    void encodeItem(ByteBuf byteBuf, String value) {
-        Assert.requireNonNull(byteBuf, "byteBuf must not be null");
+    String encodeItem(String value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBufUtil.writeUtf8(byteBuf, value);
+        return AbstractArrayCodec.escapeArrayElement(value);
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/util/Assert.java
+++ b/src/main/java/io/r2dbc/postgresql/util/Assert.java
@@ -49,7 +49,7 @@ public final class Assert {
         }
 
         if (d != dimension) {
-            throw new IllegalArgumentException(message);
+            throw new IllegalArgumentException(String.format(message, d, dimension));
         }
 
         return type;

--- a/src/test/java/io/r2dbc/postgresql/codec/CodecIntegrationTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/CodecIntegrationTest.java
@@ -120,6 +120,11 @@ final class CodecIntegrationTest {
     }
 
     @Test
+    void intTwoDimensionalArray() {
+        testCodec(Integer[][].class, new Integer[][]{{100, 200}, {300, null}}, "INT4[][]");
+    }
+
+    @Test
     void intPrimitive() {
         testCodec(Integer.class, 100, "INT4");
     }
@@ -145,6 +150,11 @@ final class CodecIntegrationTest {
     }
 
     @Test
+    void longTwoDimensionalArray() {
+        testCodec(Long[][].class, new Long[][]{{100L, 200L}, {300L, null}}, "INT8[][]");
+    }
+
+    @Test
     void longPrimitive() {
         testCodec(Long.class, 100L, "INT8");
     }
@@ -157,6 +167,11 @@ final class CodecIntegrationTest {
     @Test
     void shortArray() {
         testCodec(Short[].class, new Short[]{100, 200, 300}, "INT2[]");
+    }
+
+    @Test
+    void shortTwoDimensionalArray() {
+        testCodec(Short[][].class, new Short[][]{{100, 200}, {300, null}}, "INT2[][]");
     }
 
     @Test
@@ -174,6 +189,18 @@ final class CodecIntegrationTest {
     void stringArray() {
         testCodec(String[].class, new String[]{"test-value1", "test-value2", "test-value3"}, "BPCHAR[]");
         testCodec(String[].class, new String[]{"test-value1", "test-value2", "test-value3"}, "VARCHAR[]");
+    }
+
+    @Test
+    void stringTwoDimensionalArray() {
+        testCodec(String[][].class, new String[][]{{"test-value1"}, {"test-value2"}}, "BPCHAR[]");
+        testCodec(String[][].class, new String[][]{{"test-value1"}, {"test-value2"}}, "VARCHAR[]");
+    }
+
+    @Test
+    void stringArrayValueEscaping() {
+        testCodec(String[].class, new String[]{"NULL", null, "R \"2\" DBC", "АБ"}, "BPCHAR[]");
+        testCodec(String[].class, new String[]{"NULL", null, "R \"2\" DBC", "АБ"}, "VARCHAR[]");
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsTest.java
@@ -26,10 +26,14 @@ import java.time.ZonedDateTime;
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2_ARRAY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4_ARRAY;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT8_ARRAY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMP;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMPTZ;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR_ARRAY;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -87,6 +91,10 @@ final class DefaultCodecsTest {
         assertThat(codecs.decode(ByteBufUtils.encode(TEST, "test"), VARCHAR.getObjectId(), FORMAT_TEXT, Object.class)).isInstanceOf(String.class);
         assertThat(codecs.decode(ByteBufUtils.encode(TEST, "2018-11-04 15:35:00.847108"), TIMESTAMP.getObjectId(), FORMAT_TEXT, Object.class)).isInstanceOf(Instant.class);
         assertThat(codecs.decode(ByteBufUtils.encode(TEST, "2018-11-05 00:35:43.048593+09"), TIMESTAMPTZ.getObjectId(), FORMAT_TEXT, Object.class)).isInstanceOf(ZonedDateTime.class);
+        assertThat(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT2_ARRAY.getObjectId(), FORMAT_TEXT, Object.class)).isEqualTo(new short[]{100, 200});
+        assertThat(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT4_ARRAY.getObjectId(), FORMAT_TEXT, Object.class)).isEqualTo(new int[]{100, 200});
+        assertThat(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT8_ARRAY.getObjectId(), FORMAT_TEXT, Object.class)).isEqualTo(new long[]{100, 200});
+        assertThat(codecs.decode(ByteBufUtils.encode(TEST, "{alpha,bravo}"), VARCHAR_ARRAY.getObjectId(), FORMAT_TEXT, Object.class)).isEqualTo(new String[]{"alpha", "bravo"});
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/IntegerArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/IntegerArrayCodecTest.java
@@ -31,38 +31,98 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 final class IntegerArrayCodecTest {
 
+    private final IntegerArrayCodec codec = new IntegerArrayCodec(TEST);
+
+    private final ByteBuf SINGLE_DIM_BINARY_ARRAY = TEST
+            .buffer()
+            .writeInt(1)
+            .writeInt(0)
+            .writeInt(23)
+            .writeInt(2)
+            .writeInt(1)
+            .writeInt(4)
+            .writeInt(100)
+            .writeInt(4)
+            .writeInt(200);
+
+    private final ByteBuf TWO_DIM_BINARY_ARRAY = TEST
+            .buffer()
+            .writeInt(2) // num of dims
+            .writeInt(1) // flag: has nulls
+            .writeInt(23) // oid
+            .writeInt(2) // dim 1 length
+            .writeInt(1) // dim 1 lower bound
+            .writeInt(1) // dim 2 length
+            .writeInt(1) // dim 2 lower bound
+            .writeInt(4) // length of element
+            .writeInt(100) // value
+            .writeInt(-1); // length of null element
+
     @Test
     void decodeItem() {
-        IntegerArrayCodec codec = new IntegerArrayCodec(TEST);
-
-        assertThat(codec.decode(TEST.buffer(8).writeInt(100).writeInt(200), FORMAT_BINARY, Integer[].class)).isEqualTo(new int[]{100, 200});
-        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Integer[].class)).isEqualTo(new int[]{100, 200});
+        assertThat(codec.decode(SINGLE_DIM_BINARY_ARRAY, FORMAT_BINARY, Integer[].class)).isEqualTo(new int[]{100, 200});
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Integer[].class))
+                .isEqualTo(new int[]{100, 200});
     }
 
     @Test
-    void decodeItemNoByteBuf() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new IntegerArrayCodec(TEST).decodeItem(null, FORMAT_TEXT, null))
-            .withMessage("byteBuf must not be null");
+    void decodeItem_emptyArray() {
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{}"), FORMAT_TEXT, Integer[][].class))
+                .isEqualTo(new int[][]{});
     }
 
     @Test
-    void decodeItemNoFormat() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new IntegerArrayCodec(TEST).decodeItem(TEST.buffer(0), null, null))
-            .withMessage("format must not be null");
+    void decodeItem_emptyBinaryArray() {
+        ByteBuf buf = TEST
+                .buffer()
+                .writeInt(0)
+                .writeInt(0)
+                .writeInt(23);
+
+        assertThat(codec.decode(buf, FORMAT_BINARY, Integer[][].class)).isEqualTo(new int[][]{});
     }
 
     @Test
-    void decodeMultidimensional() {
-        IntegerArrayCodec codec = new IntegerArrayCodec(TEST);
+    void decodeItem_twoDimensionalArrayWithNull() {
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{{100},{NULL}}"), FORMAT_TEXT, Integer[][].class))
+                .isEqualTo(new Integer[][]{{100}, {null}});
+    }
 
-        assertThatIllegalArgumentException().isThrownBy(() -> codec.decode(ByteBufUtils.encode(TEST, "{{100},{200}}"), FORMAT_TEXT, Integer[][].class))
-            .withMessage("type must be an array with one dimension");
+    @Test
+    void decodeItem_twoDimensionalBinaryArrayWithNull() {
+        assertThat(codec.decode(TWO_DIM_BINARY_ARRAY, FORMAT_BINARY, Integer[][].class)).isEqualTo(new Integer[][]{{100}, {null}});
+    }
+
+    @Test
+    void decodeItem_expectedMoreDimensionsInArray() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Integer[][].class))
+                .withMessage("Dimensions mismatch: 2 expected, but 1 returned from DB");
+    }
+
+    @Test
+    void decodeItem_expectedMoreDimensionsInBinaryArray() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> codec.decode(SINGLE_DIM_BINARY_ARRAY, FORMAT_BINARY, Integer[][].class))
+                .withMessage("Dimensions mismatch: 2 expected, but 1 returned from DB");
+    }
+
+    @Test
+    void decodeItem_expectedLessDimensionsInArray() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> codec.decode(ByteBufUtils.encode(TEST, "{{100}}"), FORMAT_TEXT, Integer[].class))
+                .withMessage("Dimensions mismatch: 1 expected, but 2 returned from DB");
+    }
+
+    @Test
+    void decodeItem_expectedLessDimensionsInBinaryArray() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> codec.decode(TWO_DIM_BINARY_ARRAY, FORMAT_BINARY, Integer[].class))
+                .withMessage("Dimensions mismatch: 1 expected, but 2 returned from DB");
     }
 
     @Test
     void doCanDecode() {
-        IntegerArrayCodec codec = new IntegerArrayCodec(TEST);
-
         assertThat(codec.doCanDecode(FORMAT_TEXT, INT4)).isFalse();
         assertThat(codec.doCanDecode(FORMAT_TEXT, INT4_ARRAY)).isTrue();
         assertThat(codec.doCanDecode(FORMAT_BINARY, INT4_ARRAY)).isTrue();
@@ -70,46 +130,30 @@ final class IntegerArrayCodecTest {
 
     @Test
     void doCanDecodeNoType() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new IntegerArrayCodec(TEST).doCanDecode(null, null))
+        assertThatIllegalArgumentException().isThrownBy(() -> codec.doCanDecode(null, null))
             .withMessage("type must not be null");
     }
 
     @Test
     void encodeArray() {
-        assertThat(new IntegerArrayCodec(TEST).encodeArray(ByteBufUtils.encode(TEST, "{100,200}")))
+        assertThat(codec.encodeArray(ByteBufUtils.encode(TEST, "{100,200}")))
             .isEqualTo(new Parameter(FORMAT_TEXT, INT4_ARRAY.getObjectId(), ByteBufUtils.encode(TEST, "{100,200}")));
     }
 
     @Test
-    void encodeArrayNoByteBuf() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new IntegerArrayCodec(TEST).encodeArray(null))
-            .withMessage("byteBuf must not be null");
-    }
-
-    @Test
     void encodeItem() {
-        ByteBuf actual = TEST.buffer(3);
-
-        new IntegerArrayCodec(TEST).encodeItem(actual, 100);
-
-        assertThat(actual).isEqualTo(ByteBufUtils.encode(TEST, "100"));
-    }
-
-    @Test
-    void encodeItemNoByteBuf() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new IntegerArrayCodec(TEST).encodeItem(null, 100))
-            .withMessage("byteBuf must not be null");
+        assertThat(codec.encodeItem(100)).isEqualTo("100");
     }
 
     @Test
     void encodeItemNoValue() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new IntegerArrayCodec(TEST).encodeItem(TEST.buffer(0), null))
-            .withMessage("value must not be null");
+        assertThatIllegalArgumentException().isThrownBy(() -> codec.encodeItem(null))
+                .withMessage("value must not be null");
     }
 
     @Test
     void encodeNull() {
-        assertThat(new IntegerArrayCodec(TEST).encodeNull())
+        assertThat(codec.encodeNull())
             .isEqualTo(new Parameter(FORMAT_TEXT, INT4_ARRAY.getObjectId(), null));
     }
 }

--- a/src/test/java/io/r2dbc/postgresql/codec/IntegerArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/IntegerArrayCodecTest.java
@@ -18,6 +18,7 @@ package io.r2dbc.postgresql.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +64,16 @@ final class IntegerArrayCodecTest {
         assertThat(codec.decode(SINGLE_DIM_BINARY_ARRAY, FORMAT_BINARY, Integer[].class)).isEqualTo(new int[]{100, 200});
         assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Integer[].class))
                 .isEqualTo(new int[]{100, 200});
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void decodeObject() {
+        Codec codec = new IntegerArrayCodec(TEST);
+        codec.canDecode(PostgresqlObjectId.INT4_ARRAY.getObjectId(), FORMAT_TEXT, Object.class);
+
+        assertThat(codec.decode(SINGLE_DIM_BINARY_ARRAY, FORMAT_BINARY, Object.class)).isEqualTo(new int[]{100, 200});
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Object.class)).isEqualTo(new int[]{100, 200});
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/LongArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/LongArrayCodecTest.java
@@ -35,28 +35,20 @@ final class LongArrayCodecTest {
     void decodeItem() {
         LongArrayCodec codec = new LongArrayCodec(TEST);
 
-        assertThat(codec.decode(TEST.buffer(16).writeLong(100).writeLong(200), FORMAT_BINARY, Long[].class)).isEqualTo(new long[]{100, 200});
+        ByteBuf buf = TEST
+                .buffer()
+                .writeInt(1)
+                .writeInt(0)
+                .writeInt(20)
+                .writeInt(2)
+                .writeInt(2)
+                .writeInt(8)
+                .writeLong(100L)
+                .writeInt(8)
+                .writeLong(200L);
+
+        assertThat(codec.decode(buf, FORMAT_BINARY, Long[].class)).isEqualTo(new long[]{100, 200});
         assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Long[].class)).isEqualTo(new long[]{100, 200});
-    }
-
-    @Test
-    void decodeItemNoByteBuf() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new LongArrayCodec(TEST).decodeItem(null, FORMAT_TEXT, null))
-            .withMessage("byteBuf must not be null");
-    }
-
-    @Test
-    void decodeItemNoFormat() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new LongArrayCodec(TEST).decodeItem(TEST.buffer(0), null, null))
-            .withMessage("format must not be null");
-    }
-
-    @Test
-    void decodeMultidimensional() {
-        LongArrayCodec codec = new LongArrayCodec(TEST);
-
-        assertThatIllegalArgumentException().isThrownBy(() -> codec.decode(ByteBufUtils.encode(TEST, "{{100},{200}}"), FORMAT_TEXT, Integer[][].class))
-            .withMessage("type must be an array with one dimension");
     }
 
     @Test
@@ -88,22 +80,12 @@ final class LongArrayCodecTest {
 
     @Test
     void encodeItem() {
-        ByteBuf actual = TEST.buffer(3);
-
-        new LongArrayCodec(TEST).encodeItem(actual, 100L);
-
-        assertThat(actual).isEqualTo(ByteBufUtils.encode(TEST, "100"));
-    }
-
-    @Test
-    void encodeItemNoByteBuf() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new LongArrayCodec(TEST).encodeItem(null, 100L))
-            .withMessage("byteBuf must not be null");
+        assertThat(new LongArrayCodec(TEST).encodeItem(100L)).isEqualTo("100");
     }
 
     @Test
     void encodeItemNoValue() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new LongArrayCodec(TEST).encodeItem(TEST.buffer(0), null))
+        assertThatIllegalArgumentException().isThrownBy(() -> new LongArrayCodec(TEST).encodeItem(null))
             .withMessage("value must not be null");
     }
 

--- a/src/test/java/io/r2dbc/postgresql/codec/LongArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/LongArrayCodecTest.java
@@ -31,23 +31,23 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 final class LongArrayCodecTest {
 
+    private final ByteBuf BINARY_ARRAY = TEST
+            .buffer()
+            .writeInt(1)
+            .writeInt(0)
+            .writeInt(20)
+            .writeInt(2)
+            .writeInt(2)
+            .writeInt(8)
+            .writeLong(100L)
+            .writeInt(8)
+            .writeLong(200L);
+
     @Test
     void decodeItem() {
         LongArrayCodec codec = new LongArrayCodec(TEST);
 
-        ByteBuf buf = TEST
-                .buffer()
-                .writeInt(1)
-                .writeInt(0)
-                .writeInt(20)
-                .writeInt(2)
-                .writeInt(2)
-                .writeInt(8)
-                .writeLong(100L)
-                .writeInt(8)
-                .writeLong(200L);
-
-        assertThat(codec.decode(buf, FORMAT_BINARY, Long[].class)).isEqualTo(new long[]{100, 200});
+        assertThat(codec.decode(BINARY_ARRAY, FORMAT_BINARY, Long[].class)).isEqualTo(new long[]{100, 200});
         assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Long[].class)).isEqualTo(new long[]{100, 200});
     }
 
@@ -70,6 +70,15 @@ final class LongArrayCodecTest {
     void encodeArray() {
         assertThat(new LongArrayCodec(TEST).encodeArray(ByteBufUtils.encode(TEST, "{100,200}")))
             .isEqualTo(new Parameter(FORMAT_TEXT, INT8_ARRAY.getObjectId(), ByteBufUtils.encode(TEST, "{100,200}")));
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void decodeObject() {
+        Codec codec = new LongArrayCodec(TEST);
+
+        assertThat(codec.decode(BINARY_ARRAY, FORMAT_BINARY, Object.class)).isEqualTo(new long[]{100, 200});
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Object.class)).isEqualTo(new long[]{100, 200});
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/ShortArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/ShortArrayCodecTest.java
@@ -31,30 +31,33 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 final class ShortArrayCodecTest {
 
+    private final ByteBuf BINARY_ARRAY = TEST
+            .buffer()
+            .writeInt(1)
+            .writeInt(0)
+            .writeInt(21)
+            .writeInt(2)
+            .writeInt(2)
+            .writeInt(2)
+            .writeShort(100)
+            .writeInt(2)
+            .writeShort(200);
+
     @Test
     void decodeItem() {
         ShortArrayCodec codec = new ShortArrayCodec(TEST);
 
-        ByteBuf buf = TEST
-                .buffer()
-                .writeInt(1)
-                .writeInt(0)
-                .writeInt(21)
-                .writeInt(2)
-                .writeInt(2)
-                .writeInt(2)
-                .writeShort(100)
-                .writeInt(2)
-                .writeShort(200);
-
-        assertThat(codec.decode(buf, FORMAT_BINARY, Short[].class)).isEqualTo(new short[]{100, 200});
+        assertThat(codec.decode(BINARY_ARRAY, FORMAT_BINARY, Short[].class)).isEqualTo(new short[]{100, 200});
         assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Short[].class)).isEqualTo(new short[]{100, 200});
     }
 
     @Test
-    void decodeMultidimensional() {
-        ShortArrayCodec codec = new ShortArrayCodec(TEST);
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void decodeObject() {
+        Codec codec = new ShortArrayCodec(TEST);
 
+        assertThat(codec.decode(BINARY_ARRAY, FORMAT_BINARY, Object.class)).isEqualTo(new short[]{100, 200});
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Object.class)).isEqualTo(new short[]{100, 200});
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/ShortArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/ShortArrayCodecTest.java
@@ -35,28 +35,26 @@ final class ShortArrayCodecTest {
     void decodeItem() {
         ShortArrayCodec codec = new ShortArrayCodec(TEST);
 
-        assertThat(codec.decode(TEST.buffer(4).writeShort(100).writeShort(200), FORMAT_BINARY, Short[].class)).isEqualTo(new short[]{100, 200});
+        ByteBuf buf = TEST
+                .buffer()
+                .writeInt(1)
+                .writeInt(0)
+                .writeInt(21)
+                .writeInt(2)
+                .writeInt(2)
+                .writeInt(2)
+                .writeShort(100)
+                .writeInt(2)
+                .writeShort(200);
+
+        assertThat(codec.decode(buf, FORMAT_BINARY, Short[].class)).isEqualTo(new short[]{100, 200});
         assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Short[].class)).isEqualTo(new short[]{100, 200});
-    }
-
-    @Test
-    void decodeItemNoByteBuf() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ShortArrayCodec(TEST).decodeItem(null, FORMAT_TEXT, null))
-            .withMessage("byteBuf must not be null");
-    }
-
-    @Test
-    void decodeItemNoFormat() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ShortArrayCodec(TEST).decodeItem(TEST.buffer(0), null, null))
-            .withMessage("format must not be null");
     }
 
     @Test
     void decodeMultidimensional() {
         ShortArrayCodec codec = new ShortArrayCodec(TEST);
 
-        assertThatIllegalArgumentException().isThrownBy(() -> codec.decode(ByteBufUtils.encode(TEST, "{{100},{200}}"), FORMAT_TEXT, Integer[][].class))
-            .withMessage("type must be an array with one dimension");
     }
 
     @Test
@@ -88,22 +86,12 @@ final class ShortArrayCodecTest {
 
     @Test
     void encodeItem() {
-        ByteBuf actual = TEST.buffer(3);
-
-        new ShortArrayCodec(TEST).encodeItem(actual, (short) 100);
-
-        assertThat(actual).isEqualTo(ByteBufUtils.encode(TEST, "100"));
-    }
-
-    @Test
-    void encodeItemNoByteBuf() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ShortArrayCodec(TEST).encodeItem(null, (short) 100))
-            .withMessage("byteBuf must not be null");
+        assertThat(new ShortArrayCodec(TEST).encodeItem((short) 100)).isEqualTo("100");
     }
 
     @Test
     void encodeItemNoValue() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ShortArrayCodec(TEST).encodeItem(TEST.buffer(0), null))
+        assertThatIllegalArgumentException().isThrownBy(() -> new ShortArrayCodec(TEST).encodeItem(null))
             .withMessage("value must not be null");
     }
 

--- a/src/test/java/io/r2dbc/postgresql/codec/StringArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/StringArrayCodecTest.java
@@ -37,25 +37,34 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 final class StringArrayCodecTest {
 
+    private final ByteBuf BINARY_ARRAY = TEST
+            .buffer()
+            .writeInt(1)
+            .writeInt(0)
+            .writeInt(1043)
+            .writeInt(2)
+            .writeInt(2)
+            .writeInt(3)
+            .writeBytes("abc".getBytes())
+            .writeInt(3)
+            .writeBytes("def".getBytes());
+
     @Test
     void decodeItem() {
         StringArrayCodec codec = new StringArrayCodec(TEST);
 
-        ByteBuf buf = TEST
-                .buffer()
-                .writeInt(1)
-                .writeInt(0)
-                .writeInt(1043)
-                .writeInt(2)
-                .writeInt(2)
-                .writeInt(3)
-                .writeBytes("abc".getBytes())
-                .writeInt(3)
-                .writeBytes("def".getBytes());
-
-        assertThat(codec.decode(buf, FORMAT_BINARY, String[].class)).isEqualTo(new String[]{"abc", "def"});
+        assertThat(codec.decode(BINARY_ARRAY, FORMAT_BINARY, String[].class)).isEqualTo(new String[]{"abc", "def"});
         assertThat(codec.decode(ByteBufUtils.encode(TEST, "{alpha,bravo}"), FORMAT_TEXT, String[].class))
             .isEqualTo(new String[]{"alpha", "bravo"});
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void decodeObject() {
+        Codec codec = new StringArrayCodec(TEST);
+
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{alpha,bravo}"), FORMAT_TEXT, Object.class))
+                .isEqualTo(new String[]{"alpha", "bravo"});
     }
 
     @Test


### PR DESCRIPTION
Implementation for #42 .

Notes:
- binary format is not tested with real queries. I took value dumps from queries with current postgresql jdbc driver and placed them inside unit tests. We should consider implementing "force binary" option to be able to write integration tests for binary format;
- IntegerArrayCodecTest has much more tests then Long/Short/String* siblings. I think we should parametrize these test to avoid copy-paste (not included in current PR);
- AbstractArrayCodec::buildArrayList is very similar to original https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java#L413 implementation