### PR TITLE
Fix for decoding array-typed value into Object

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractArrayCodec.java
@@ -56,7 +56,9 @@ abstract class AbstractArrayCodec<T> extends AbstractCodec<Object[]> {
         Assert.requireNonNull(byteBuf, "byteBuf must not be null");
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
-        Assert.requireArrayDimension(type, 1, "type must be an array with one dimension");
+        if ((Class<?>) type != Object.class) {
+            Assert.requireArrayDimension(type, 1, "type must be an array with one dimension");
+        }
 
         List<T> items = new ArrayList<>();
 

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
@@ -36,7 +36,7 @@ abstract class AbstractCodec<T> implements Codec<T> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return isTypeAssignable(type) &&
+        return (type == Object.class || isTypeAssignable(type)) &&
             doCanDecode(format, PostgresqlObjectId.valueOf(dataType));
     }
 

--- a/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsTest.java
@@ -26,10 +26,14 @@ import java.time.ZonedDateTime;
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2_ARRAY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4_ARRAY;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT8_ARRAY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMP;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMPTZ;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR_ARRAY;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -87,6 +91,10 @@ final class DefaultCodecsTest {
         assertThat(codecs.decode(ByteBufUtils.encode(TEST, "test"), VARCHAR.getObjectId(), FORMAT_TEXT, Object.class)).isInstanceOf(String.class);
         assertThat(codecs.decode(ByteBufUtils.encode(TEST, "2018-11-04 15:35:00.847108"), TIMESTAMP.getObjectId(), FORMAT_TEXT, Object.class)).isInstanceOf(Instant.class);
         assertThat(codecs.decode(ByteBufUtils.encode(TEST, "2018-11-05 00:35:43.048593+09"), TIMESTAMPTZ.getObjectId(), FORMAT_TEXT, Object.class)).isInstanceOf(ZonedDateTime.class);
+        assertThat(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT2_ARRAY.getObjectId(), FORMAT_TEXT, Object.class)).isEqualTo(new short[]{100, 200});
+        assertThat(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT4_ARRAY.getObjectId(), FORMAT_TEXT, Object.class)).isEqualTo(new int[]{100, 200});
+        assertThat(codecs.decode(ByteBufUtils.encode(TEST, "{100,200}"), INT8_ARRAY.getObjectId(), FORMAT_TEXT, Object.class)).isEqualTo(new long[]{100, 200});
+        assertThat(codecs.decode(ByteBufUtils.encode(TEST, "{alpha,bravo}"), VARCHAR_ARRAY.getObjectId(), FORMAT_TEXT, Object.class)).isEqualTo(new String[]{"alpha", "bravo"});
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/IntegerArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/IntegerArrayCodecTest.java
@@ -18,6 +18,7 @@ package io.r2dbc.postgresql.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,16 @@ final class IntegerArrayCodecTest {
 
         assertThat(codec.decode(TEST.buffer(8).writeInt(100).writeInt(200), FORMAT_BINARY, Integer[].class)).isEqualTo(new int[]{100, 200});
         assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Integer[].class)).isEqualTo(new int[]{100, 200});
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void decodeObject() {
+        Codec codec = new IntegerArrayCodec(TEST);
+        codec.canDecode(PostgresqlObjectId.INT4_ARRAY.getObjectId(), FORMAT_TEXT, Object.class);
+
+        assertThat(codec.decode(TEST.buffer(8).writeInt(100).writeInt(200), FORMAT_BINARY, Object.class)).isEqualTo(new int[]{100, 200});
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Object.class)).isEqualTo(new int[]{100, 200});
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/LongArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/LongArrayCodecTest.java
@@ -40,6 +40,15 @@ final class LongArrayCodecTest {
     }
 
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void decodeObject() {
+        Codec codec = new LongArrayCodec(TEST);
+
+        assertThat(codec.decode(TEST.buffer(16).writeLong(100).writeLong(200), FORMAT_BINARY, Object.class)).isEqualTo(new long[]{100, 200});
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Object.class)).isEqualTo(new long[]{100, 200});
+    }
+
+    @Test
     void decodeItemNoByteBuf() {
         assertThatIllegalArgumentException().isThrownBy(() -> new LongArrayCodec(TEST).decodeItem(null, FORMAT_TEXT, null))
             .withMessage("byteBuf must not be null");

--- a/src/test/java/io/r2dbc/postgresql/codec/ShortArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/ShortArrayCodecTest.java
@@ -40,6 +40,15 @@ final class ShortArrayCodecTest {
     }
 
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void decodeObject() {
+        Codec codec = new ShortArrayCodec(TEST);
+
+        assertThat(codec.decode(TEST.buffer(4).writeShort(100).writeShort(200), FORMAT_BINARY, Object.class)).isEqualTo(new short[]{100, 200});
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{100,200}"), FORMAT_TEXT, Object.class)).isEqualTo(new short[]{100, 200});
+    }
+
+    @Test
     void decodeItemNoByteBuf() {
         assertThatIllegalArgumentException().isThrownBy(() -> new ShortArrayCodec(TEST).decodeItem(null, FORMAT_TEXT, null))
             .withMessage("byteBuf must not be null");

--- a/src/test/java/io/r2dbc/postgresql/codec/StringArrayCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/StringArrayCodecTest.java
@@ -44,6 +44,15 @@ final class StringArrayCodecTest {
     }
 
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void decodeObject() {
+        Codec codec = new StringArrayCodec(TEST);
+
+        assertThat(codec.decode(ByteBufUtils.encode(TEST, "{alpha,bravo}"), FORMAT_TEXT, Object.class))
+            .isEqualTo(new String[]{"alpha", "bravo"});
+    }
+
+    @Test
     void decodeItemNoByteBuf() {
         assertThatIllegalArgumentException().isThrownBy(() -> new StringArrayCodec(TEST).decodeItem(null, FORMAT_TEXT, null))
             .withMessage("byteBuf must not be null");


### PR DESCRIPTION
[#67]

> Well, I can fix this with a few lines, but the whole Object.class decoding (not only for arrays) thing stands on type erasure, I'm not sure how bad is that.