### PR TITLE
Add ConnectionFactoryProvider.getDriver() implementation

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -98,4 +98,9 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
 
         return true;
     }
+
+    @Override
+    public String getDriver() {
+        return POSTGRESQL_DRIVER;
+    }
 }

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
@@ -102,4 +102,9 @@ final class PostgresqlConnectionFactoryProviderTest {
             .option(USER, "test-user")
             .build())).isTrue();
     }
+
+    @Test
+    void returnsDriverIdentifier() {
+        assertThat(this.provider.getDriver()).isEqualTo(POSTGRESQL_DRIVER);
+    }
 }


### PR DESCRIPTION
`getDriver()` returns the driver identifier postgresql.

[resolves #77]