### PR TITLE
Remove uneeded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,16 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.r2dbc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,10 +85,6 @@
             <artifactId>reactor-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.projectreactor.addons</groupId>
-            <artifactId>reactor-extra</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
             <exclusions>

--- a/src/main/java/io/r2dbc/postgresql/IndefiniteStatementCache.java
+++ b/src/main/java/io/r2dbc/postgresql/IndefiniteStatementCache.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static reactor.function.TupleUtils.function;
-
 final class IndefiniteStatementCache implements StatementCache {
 
     private final Map<Tuple2<String, List<Integer>>, Mono<String>> cache = new HashMap<>();
@@ -48,7 +46,8 @@ final class IndefiniteStatementCache implements StatementCache {
         Assert.requireNonNull(binding, "binding must not be null");
         Assert.requireNonNull(sql, "sql must not be null");
 
-        return this.cache.computeIfAbsent(Tuples.of(sql, binding.getParameterTypes()), function(this::parse));
+        return this.cache.computeIfAbsent(Tuples.of(sql, binding.getParameterTypes()),
+                tuple -> this.parse(tuple.getT1(), tuple.getT2()));
     }
 
     @Override


### PR DESCRIPTION
As a low level library, I think `r2dbc-postgresql` should limit its dependencies. It seems Netty http support is not needed and `reactor-extra` is only used for tiny optional utility functions. I have chosen in this PR to remove usage of `function()` which is my preferred solution, another possibility is to copy `TupleUtils` in `r2dbc-postgresql`.