### PR TITLE
Fix for multiple usage of same parameter in extended query

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
+++ b/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
@@ -28,7 +28,9 @@ import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 
 import static io.r2dbc.postgresql.client.ExtendedQueryMessageFlow.PARAMETER_SYMBOL;
@@ -154,10 +156,13 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
 
     private static int expectedSize(String sql) {
         Matcher m = PARAMETER_SYMBOL.matcher(sql);
+        Set<String> paramNames = new HashSet<>();
 
         int count = 0;
         while (m.find()) {
-            count++;
+            if (paramNames.add(m.group())) {
+                count++;
+            }
         }
 
         return count;

--- a/src/test/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatementTest.java
+++ b/src/test/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatementTest.java
@@ -206,7 +206,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1-$1", this.statementCache, false)
             .bind("$1", 100)
             .add()
             .bind("$1", 200)


### PR DESCRIPTION
Since c9bb24aa we can't use the same parameter twice (like 'SELECT $1 + $1').