### PR TITLE
Avoid array index out of bounds on missing result size in tag

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/message/backend/CommandComplete.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/CommandComplete.java
@@ -118,7 +118,7 @@ public final class CommandComplete implements BackendMessage {
             return new CommandComplete(tokens[0], Integer.parseInt(tokens[1]), Integer.parseInt(tokens[2]));
         } else if (Stream.of("COPY", "DELETE", "FETCH", "MOVE", "SELECT", "UPDATE").anyMatch(tag::startsWith)) {
             String[] tokens = tag.split(" ");
-            return new CommandComplete(tokens[0], null, Integer.parseInt(tokens[1]));
+            return new CommandComplete(tokens[0], null, tokens.length>1?Integer.parseInt(tokens[1]):null);
         } else {
             return new CommandComplete(tag, null, null);
         }

--- a/src/test/java/io/r2dbc/postgresql/message/backend/CommandCompleteTest.java
+++ b/src/test/java/io/r2dbc/postgresql/message/backend/CommandCompleteTest.java
@@ -112,7 +112,17 @@ final class CommandCompleteTest {
                 return buffer;
             })
             .isEqualTo(new CommandComplete("SELECT", null, 100));
+        assertThat(CommandComplete.class)
+            .decoded(buffer -> {
+                buffer.writeCharSequence("SELECT", UTF_8);
+                buffer.writeByte(0);
+
+                return buffer;
+            })
+            .isEqualTo(new CommandComplete("SELECT", null, null));
     }
+    
+
 
     @Test
     void decodeUpdate() {


### PR DESCRIPTION
Select commands on GreenplumDB (possibly older versions of Postgresql as well) do not return the amount of result records in the tag.

Added a lenght check on the tokenized tag to prevent array index out of bounds.