### PR TITLE
Parallel mapping fix

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlRow.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlRow.java
@@ -82,16 +82,10 @@ public final class PostgresqlRow implements Row {
 
         ByteBuf data = column.getByteBuf();
         if (data != null) {
-            data.markReaderIndex();
+            data = data.slice();
         }
 
-        T value = this.codecs.decode(data, column.getDataType(), column.getFormat(), type);
-
-        if (data != null) {
-            data.resetReaderIndex();
-        }
-
-        return value;
+        return this.codecs.decode(data, column.getDataType(), column.getFormat(), type);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
@@ -150,8 +150,11 @@ public final class ReactorNettyClient implements Client {
             .concatMap(message -> connection.outbound().send(message.encode(connection.outbound().alloc())))
             .then();
 
-        Flux.merge(receive, request)
+        connection.onDispose()
             .doFinally(s -> decoder.dispose())
+            .subscribe();
+
+        Flux.merge(receive, request)
             .onErrorResume(throwable -> {
                 this.logger.error("Connection Error", throwable);
                 return close();

--- a/src/main/java/io/r2dbc/postgresql/message/backend/BackendMessageDecoder.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/BackendMessageDecoder.java
@@ -141,7 +141,11 @@ public final class BackendMessageDecoder {
 
                 return byteBuf;
             },
-            CompositeByteBuf::discardReadComponents);
+            buf -> {
+                if (buf.refCnt() == 1) {
+                    buf.discardReadComponents();
+                }
+            });
     }
 
     public void dispose() {

--- a/src/main/java/io/r2dbc/postgresql/message/backend/BackendMessageEnvelopeDecoder.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/BackendMessageEnvelopeDecoder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.r2dbc.postgresql.message.backend;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.util.ReferenceCountUtil;
+import io.r2dbc.postgresql.util.Assert;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import static io.r2dbc.postgresql.message.backend.BackendMessageUtils.getEnvelope;
+
+public class BackendMessageEnvelopeDecoder implements Function<ByteBuf, Publisher<CompositeByteBuf>> {
+
+    private final CompositeByteBuf byteBuf;
+
+    private final AtomicBoolean disposed = new AtomicBoolean();
+
+    public BackendMessageEnvelopeDecoder(ByteBufAllocator allocator) {
+        this.byteBuf = allocator.compositeBuffer();
+    }
+
+
+    /**
+     * Splits a {@link ByteBuf} into a {@link Flux} of {@link CompositeByteBuf}s contains exactly one backend envelope.
+     * If the {@link ByteBuf} does not end on a {@link BackendMessage} boundary, the {@link ByteBuf} will be retained until
+     * an the concatenated contents of all retained {@link ByteBuf}s is a {@link BackendMessage} boundary.
+     *
+     * @param in the {@link ByteBuf} to decode
+     * @return a {@link Flux} of {@link BackendMessage}s
+     */
+    @Override
+    public Flux<CompositeByteBuf> apply(ByteBuf in) {
+        Assert.requireNonNull(in, "in must not be null");
+
+        this.byteBuf.addComponent(true, in);
+
+        return EmitterProcessor.create(sink -> {
+            try {
+                CompositeByteBuf envelope = getEnvelope(this.byteBuf);
+                while (envelope != null) {
+                    sink.next(envelope);
+                    envelope = getEnvelope(this.byteBuf);
+                }
+                sink.complete();
+            } finally {
+                this.byteBuf.discardReadComponents();
+            }
+        });
+    }
+
+
+    public void dispose() {
+        if (this.disposed.compareAndSet(false, true)) {
+            ReferenceCountUtil.release(this.byteBuf);
+        }
+    }
+}

--- a/src/main/java/io/r2dbc/postgresql/message/backend/BackendMessageUtils.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/BackendMessageUtils.java
@@ -17,8 +17,11 @@
 package io.r2dbc.postgresql.message.backend;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.r2dbc.postgresql.util.Assert;
 import reactor.util.annotation.Nullable;
+
+import java.util.List;
 
 import static io.netty.util.CharsetUtil.UTF_8;
 
@@ -29,14 +32,14 @@ final class BackendMessageUtils {
     private BackendMessageUtils() {
     }
 
-    static ByteBuf getBody(ByteBuf in) {
+    static CompositeByteBuf getBody(CompositeByteBuf in) {
         Assert.requireNonNull(in, "in must not be null");
-
-        return in.readSlice(in.readInt() - 4);
+        int length = in.readInt() - 4;
+        return readComposite(in, length);
     }
 
     @Nullable
-    static ByteBuf getEnvelope(ByteBuf in) {
+    static CompositeByteBuf getEnvelope(CompositeByteBuf in) {
         Assert.requireNonNull(in, "in must not be null");
 
         if (in.readableBytes() < 5) {
@@ -48,7 +51,20 @@ final class BackendMessageUtils {
             return null;
         }
 
-        return in.readSlice(length);
+        return readComposite(in, length);
+    }
+
+    static CompositeByteBuf readComposite(CompositeByteBuf in, int length) {
+        if (length == 0) {
+            return in.alloc().compositeBuffer(1);
+        }
+        List<ByteBuf> decompose = in.decompose(in.readerIndex(), length);
+        CompositeByteBuf byteBufs = in.alloc().compositeBuffer(decompose.size());
+        for (ByteBuf byteBuf : decompose) {
+            byteBufs.addComponent(true, byteBuf.retain());
+        }
+        in.readSlice(length);
+        return byteBufs;
     }
 
     static String readCStringUTF8(ByteBuf src) {

--- a/src/main/java/io/r2dbc/postgresql/message/backend/BackendMessageUtils.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/BackendMessageUtils.java
@@ -32,10 +32,10 @@ final class BackendMessageUtils {
     private BackendMessageUtils() {
     }
 
-    static CompositeByteBuf getBody(CompositeByteBuf in) {
+    static ByteBuf getBody(ByteBuf in) {
         Assert.requireNonNull(in, "in must not be null");
-        int length = in.readInt() - 4;
-        return readComposite(in, length);
+
+        return in.readSlice(in.readInt() - 4);
     }
 
     @Nullable

--- a/src/main/java/io/r2dbc/postgresql/message/backend/CopyData.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/CopyData.java
@@ -77,7 +77,7 @@ public final class CopyData implements BackendMessage {
     static CopyData decode(ByteBuf in) {
         Assert.requireNonNull(in, "in must not be null");
 
-        return new CopyData(in.readSlice(in.readableBytes()));
+        return new CopyData(in.readSlice(in.readableBytes()).retain());
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/message/backend/DataRow.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/DataRow.java
@@ -17,7 +17,6 @@
 package io.r2dbc.postgresql.message.backend;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.CompositeByteBuf;
 import io.r2dbc.postgresql.util.Assert;
 import reactor.util.annotation.Nullable;
 
@@ -44,7 +43,7 @@ public final class DataRow implements BackendMessage {
         this.columns = Assert.requireNonNull(columns, "columns must not be null");
 
         for (ByteBuf column : this.columns) {
-            if (column != null && !(column instanceof CompositeByteBuf)) {
+            if (column != null) {
                 column.retain();
             }
         }
@@ -111,13 +110,7 @@ public final class DataRow implements BackendMessage {
         Assert.requireNonNull(in, "in must not be null");
 
         int length = in.readInt();
-        if (NULL == length) {
-            return null;
-        }
-
-        return in instanceof CompositeByteBuf
-            ? BackendMessageUtils.readComposite((CompositeByteBuf) in, length)
-            : in.readSlice(length);
+        return NULL == length ? null : in.readSlice(length);
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/message/backend/BackendMessageDecoderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/message/backend/BackendMessageDecoderTest.java
@@ -17,71 +17,61 @@
 package io.r2dbc.postgresql.message.backend;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-import reactor.test.StepVerifier.FirstStep;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import static io.netty.util.CharsetUtil.UTF_8;
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.message.backend.Field.FieldType.CODE;
 import static io.r2dbc.postgresql.message.backend.ReadyForQuery.TransactionStatus.IDLE;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.fail;
 
 final class BackendMessageDecoderTest {
 
     @Test
     void authenticationCleartextPassword() {
-        decode('R', buffer -> buffer.writeInt(3))
-            .expectNext(AuthenticationCleartextPassword.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(3));
+        assertThat(message).isEqualTo(AuthenticationCleartextPassword.INSTANCE);
     }
 
     @Test
     void authenticationGSS() {
-        decode('R', buffer -> buffer.writeInt(7))
-            .expectNext(AuthenticationGSS.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(7));
+        assertThat(message).isEqualTo(AuthenticationGSS.INSTANCE);
     }
 
     @Test
     void authenticationGSSContinue() {
-        decode('R', buffer -> buffer.writeInt(8).writeInt(100))
-            .expectNext(new AuthenticationGSSContinue(TEST.buffer(4).writeInt(100)))
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(8).writeInt(100));
+        assertThat(message).isEqualTo(new AuthenticationGSSContinue(TEST.buffer(4).writeInt(100)));
     }
 
     @Test
     void authenticationKerberosV5() {
-        decode('R', buffer -> buffer.writeInt(2))
-            .expectNext(AuthenticationKerberosV5.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(2));
+        assertThat(message).isEqualTo(AuthenticationKerberosV5.INSTANCE);
     }
 
     @Test
     void authenticationMD5Password() {
-        decode('R', buffer -> buffer.writeInt(5).writeInt(100))
-            .expectNext(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(5).writeInt(100));
+        assertThat(message).isEqualTo(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)));
     }
 
     @Test
     void authenticationOk() {
-        decode('R', buffer -> buffer.writeInt(0))
-            .expectNext(AuthenticationOk.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(0));
+        assertThat(message).isEqualTo(AuthenticationOk.INSTANCE);
     }
 
     @Test
     void authenticationSASL() {
-        decode('R', buffer -> {
+        BackendMessage message = decode('R', buffer -> {
             buffer.writeInt(10);
 
             buffer.writeCharSequence("test-authentication-mechanism", UTF_8);
@@ -90,221 +80,173 @@ final class BackendMessageDecoderTest {
             buffer.writeByte(0);
 
             return buffer;
-        })
-            .expectNext(new AuthenticationSASL(Collections.singletonList("test-authentication-mechanism")))
-            .verifyComplete();
+        });
+        assertThat(message).isEqualTo(new AuthenticationSASL(Collections.singletonList("test-authentication-mechanism")));
     }
 
     @Test
     void authenticationSASLContinue() {
-        decode('R', buffer -> buffer.writeInt(11).writeInt(100))
-            .expectNext(new AuthenticationSASLContinue(TEST.buffer(4).writeInt(100)))
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(11).writeInt(100));
+        assertThat(message).isEqualTo(new AuthenticationSASLContinue(TEST.buffer(4).writeInt(100)));
     }
 
     @Test
     void authenticationSASLFinal() {
-        decode('R', buffer -> buffer.writeInt(12).writeInt(100))
-            .expectNext(new AuthenticationSASLFinal(TEST.buffer(4).writeInt(100)))
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(12).writeInt(100));
+        assertThat(message).isEqualTo(new AuthenticationSASLFinal(TEST.buffer(4).writeInt(100)));
     }
 
     @Test
     void authenticationSCMCredential() {
-        decode('R', buffer -> buffer.writeInt(6))
-            .expectNext(AuthenticationSCMCredential.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(6));
+        assertThat(message).isEqualTo(AuthenticationSCMCredential.INSTANCE);
     }
 
     @Test
     void authenticationSSPI() {
-        decode('R', buffer -> buffer.writeInt(9))
-            .expectNext(AuthenticationSSPI.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('R', buffer -> buffer.writeInt(9));
+        assertThat(message).isEqualTo(AuthenticationSSPI.INSTANCE);
     }
 
     @Test
     void backendKeyData() {
-        decode('K', buffer -> buffer.writeInt(100).writeInt(200))
-            .expectNext(new BackendKeyData(100, 200))
-            .verifyComplete();
+        BackendMessage message = decode('K', buffer -> buffer.writeInt(100).writeInt(200));
+        assertThat(message).isEqualTo(new BackendKeyData(100, 200));
     }
 
     @Test
     void bindComplete() {
-        decode('2', buffer -> buffer)
-            .expectNext(BindComplete.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('2', buffer -> buffer);
+        assertThat(message).isEqualTo(BindComplete.INSTANCE);
     }
 
     @Test
     void closeComplete() {
-        decode('3', buffer -> buffer)
-            .expectNext(CloseComplete.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('3', buffer -> buffer);
+        assertThat(message).isEqualTo(CloseComplete.INSTANCE);
     }
 
     @Test
     void commandComplete() {
-        decode('C', buffer -> {
+        BackendMessage message = decode('C', buffer -> {
             buffer.writeCharSequence("COPY 100", UTF_8);
             buffer.writeByte(0);
 
             return buffer;
-        })
-            .expectNext(new CommandComplete("COPY", null, 100))
-            .verifyComplete();
+        });
+        assertThat(message).isEqualTo(new CommandComplete("COPY", null, 100));
     }
 
     @Test
     void copyBothResponse() {
-        decode('W', buffer -> buffer
+        BackendMessage message = decode('W', buffer -> buffer
             .writeByte(1)
             .writeShort(1)
-            .writeShort(1))
-            .expectNext(new CopyBothResponse(Collections.singletonList(FORMAT_BINARY), FORMAT_BINARY))
-            .verifyComplete();
+            .writeShort(1));
+        assertThat(message).isEqualTo(new CopyBothResponse(Collections.singletonList(FORMAT_BINARY), FORMAT_BINARY));
     }
 
     @Test
     void copyData() {
-        decode('d', buffer -> buffer.writeInt(100))
-            .expectNext(new CopyData(TEST.buffer(4).writeInt(100)))
-            .verifyComplete();
+        BackendMessage message = decode('d', buffer -> buffer.writeInt(100));
+        assertThat(message).isEqualTo(new CopyData(TEST.buffer(4).writeInt(100)));
     }
 
     @Test
     void copyDone() {
-        decode('c', buffer -> buffer)
-            .expectNext(CopyDone.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('c', buffer -> buffer);
+        assertThat(message).isEqualTo(CopyDone.INSTANCE);
     }
 
     @Test
     void copyInResponse() {
-        decode('G', buffer -> buffer
+        BackendMessage message = decode('G', buffer -> buffer
             .writeByte(1)
             .writeShort(1)
-            .writeShort(1))
-            .expectNext(new CopyInResponse(Collections.singletonList(FORMAT_BINARY), FORMAT_BINARY))
-            .verifyComplete();
+            .writeShort(1));
+        assertThat(message).isEqualTo(new CopyInResponse(Collections.singletonList(FORMAT_BINARY), FORMAT_BINARY));
     }
 
     @Test
     void copyOutResponse() {
-        decode('H', buffer -> buffer
+        BackendMessage message = decode('H', buffer -> buffer
             .writeByte(1)
             .writeShort(1)
-            .writeShort(1))
-            .expectNext(new CopyOutResponse(Collections.singletonList(FORMAT_BINARY), FORMAT_BINARY))
-            .verifyComplete();
+            .writeShort(1));
+        assertThat(message).isEqualTo(new CopyOutResponse(Collections.singletonList(FORMAT_BINARY), FORMAT_BINARY));
     }
 
     @Test
     void dataRow() {
-        decodeWithRelease('D', message -> Mono.fromRunnable(() -> {
-                assertThat(message).isEqualTo(new DataRow(Collections.singletonList(TEST.buffer(4).writeInt(100))));
-                ((DataRow) message).release();
-            }),
-            buffer -> buffer
-                .writeShort(1)
-                .writeInt(4)
-                .writeInt(100))
-            .expectNextCount(1)
-            .verifyComplete();
-    }
-
-    @Test
-    void dataRowParallel() {
-        decodeWithRelease('D', message -> Mono.just("test")
-                .delayElement(Duration.ofMillis(1))
-                .then(Mono.fromRunnable(() -> {
-                    assertThat(message).isEqualTo(new DataRow(Collections.singletonList(TEST.buffer(4).writeInt(100))));
-                    ((DataRow) message).release();
-                })),
-            buffer -> buffer
-                .writeShort(1)
-                .writeInt(4)
-                .writeInt(100))
-            .expectNextCount(1)
-            .verifyComplete();
+        DataRow message = (DataRow) decode('D', buffer -> buffer
+            .writeShort(1)
+            .writeInt(4)
+            .writeInt(100));
+        assertThat(message).isEqualTo(new DataRow(Collections.singletonList(TEST.buffer(4).writeInt(100))));
+        message.release();
     }
 
     @Test
     void emptyQueryResponse() {
-        decode('I', buffer -> buffer)
-            .expectNext(EmptyQueryResponse.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('I', buffer -> buffer);
+        assertThat(message).isEqualTo(EmptyQueryResponse.INSTANCE);
     }
 
     @Test
     void errorResponse() {
-        decode('E', buffer -> {
+        BackendMessage message = decode('E', buffer -> {
             buffer.writeByte('C');
 
             buffer.writeCharSequence("test-value", UTF_8);
             buffer.writeByte(0);
 
             return buffer;
-        })
-            .expectNext(new ErrorResponse(Collections.singletonList(new Field(CODE, "test-value"))))
-            .verifyComplete();
+        });
+        assertThat(message).isEqualTo(new ErrorResponse(Collections.singletonList(new Field(CODE, "test-value"))));
     }
 
     @Test
     void functionCallResponse() {
-        decode('V', buffer -> buffer.writeInt(4).writeInt(100))
-            .expectNext(new FunctionCallResponse(TEST.buffer(4).writeInt(100)))
-            .verifyComplete();
+        BackendMessage message = decode('V', buffer -> buffer.writeInt(4).writeInt(100));
+        assertThat(message).isEqualTo(new FunctionCallResponse(TEST.buffer(4).writeInt(100)));
     }
 
     @Test
     void invalidAuthenticationMessageType() {
-        decode('R', buffer -> buffer
-            .writeInt(100))
-            .expectErrorSatisfies(error -> assertThat(error).isInstanceOf(IllegalArgumentException.class).hasMessage("100 is not a valid authentication type"))
-            .verify();
+        try {
+            decode('R', buffer -> buffer.writeInt(100));
+            fail("Exception expected");
+        } catch (Exception error) {
+            assertThat(error).isInstanceOf(IllegalArgumentException.class).hasMessage("100 is not a valid authentication type");
+        }
     }
 
     @Test
     void invalidMessageType() {
-        decode('Q', buffer -> buffer)
-            .expectErrorSatisfies(error -> assertThat(error).isInstanceOf(IllegalArgumentException.class).hasMessage("Q is not a valid message type"))
-            .verify();
-    }
-
-    @Test
-    void multiple() {
-        decode('R', buffer -> buffer.writeInt(0), buffer -> buffer.writeInt(0))
-            .expectNext(AuthenticationOk.INSTANCE)
-            .expectNext(AuthenticationOk.INSTANCE)
-            .verifyComplete();
-    }
-
-    @Test
-    void noData() {
-        decode('n', buffer -> buffer)
-            .expectNext(NoData.INSTANCE)
-            .verifyComplete();
+        try {
+            decode('Q', buffer -> buffer);
+            fail("Exception expected");
+        } catch (Exception error) {
+            assertThat(error).isInstanceOf(IllegalArgumentException.class).hasMessage("Q is not a valid message type");
+        }
     }
 
     @Test
     void noticeResponse() {
-        decode('N', buffer -> {
+        BackendMessage message = decode('N', buffer -> {
             buffer.writeByte('C');
 
             buffer.writeCharSequence("test-value", UTF_8);
             buffer.writeByte(0);
 
             return buffer;
-        })
-            .expectNext(new NoticeResponse(Collections.singletonList(new Field(CODE, "test-value"))))
-            .verifyComplete();
+        });
+        assertThat(message).isEqualTo(new NoticeResponse(Collections.singletonList(new Field(CODE, "test-value"))));
     }
 
     @Test
     void notificationResponse() {
-        decode('A', buffer -> {
+        BackendMessage message = decode('A', buffer -> {
             buffer.writeInt(100);
 
             buffer.writeCharSequence("test-name", UTF_8);
@@ -314,23 +256,21 @@ final class BackendMessageDecoderTest {
             buffer.writeByte(0);
 
             return buffer;
-        })
-            .expectNext(new NotificationResponse("test-name", "test-payload", 100))
-            .verifyComplete();
+        });
+        assertThat(message).isEqualTo(new NotificationResponse("test-name", "test-payload", 100));
     }
 
     @Test
     void parameterDescription() {
-        decode('t', buffer -> buffer
+        BackendMessage message = decode('t', buffer -> buffer
             .writeShort(1)
-            .writeInt(100))
-            .expectNext(new ParameterDescription(Collections.singletonList(100)))
-            .verifyComplete();
+            .writeInt(100));
+        assertThat(message).isEqualTo(new ParameterDescription(Collections.singletonList(100)));
     }
 
     @Test
     void parameterStatus() {
-        decode('S', buffer -> {
+        BackendMessage message = decode('S', buffer -> {
             buffer.writeCharSequence("test-name", UTF_8);
             buffer.writeByte(0);
 
@@ -338,35 +278,31 @@ final class BackendMessageDecoderTest {
             buffer.writeByte(0);
 
             return buffer;
-        })
-            .expectNext(new ParameterStatus("test-name", "test-value"))
-            .verifyComplete();
+        });
+        assertThat(message).isEqualTo(new ParameterStatus("test-name", "test-value"));
     }
 
     @Test
     void parseComplete() {
-        decode('1', buffer -> buffer)
-            .expectNext(ParseComplete.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('1', buffer -> buffer);
+        assertThat(message).isEqualTo(ParseComplete.INSTANCE);
     }
 
     @Test
     void portalSuspended() {
-        decode('s', buffer -> buffer)
-            .expectNext(PortalSuspended.INSTANCE)
-            .verifyComplete();
+        BackendMessage message = decode('s', buffer -> buffer);
+        assertThat(message).isEqualTo(PortalSuspended.INSTANCE);
     }
 
     @Test
     void readyForQuery() {
-        decode('Z', buffer -> buffer.writeByte('I'))
-            .expectNext(new ReadyForQuery(IDLE))
-            .verifyComplete();
+        BackendMessage message = decode('Z', buffer -> buffer.writeByte('I'));
+        assertThat(message).isEqualTo(new ReadyForQuery(IDLE));
     }
 
     @Test
     void rowDescription() {
-        decode('T', buffer -> {
+        BackendMessage message = decode('T', buffer -> {
             buffer.writeShort(1);
 
             buffer.writeCharSequence("test-name", UTF_8);
@@ -381,39 +317,20 @@ final class BackendMessageDecoderTest {
                 .writeShort(1);
 
             return buffer;
-        })
-            .expectNext(new RowDescription(Collections.singletonList(new RowDescription.Field((short) 100, 200, 300, (short) 400, FORMAT_BINARY, "test-name", 500))))
-            .verifyComplete();
+        });
+        assertThat(message).isEqualTo(new RowDescription(Collections.singletonList(new RowDescription.Field((short) 100, 200, 300, (short) 400, FORMAT_BINARY, "test-name", 500))));
     }
 
-    @SafeVarargs
-    @SuppressWarnings("varargs")
-    private final FirstStep<BackendMessage> decode(char discriminator, Function<ByteBuf, ByteBuf>... decodes) {
-        return decodeWithRelease(discriminator, message -> Mono.empty(), decodes);
-    }
-
-    @SafeVarargs
-    @SuppressWarnings("varargs")
-    private final FirstStep<BackendMessage> decodeWithRelease(char discriminator, Function<BackendMessage, Mono<?>> release, Function<ByteBuf, ByteBuf>... decodes) {
-        ByteBuf data = Stream.of(decodes)
-            .map(decode -> decode.apply(TEST.buffer()))
-            .map(payload ->
-                TEST.buffer(5 + payload.readableBytes())
-                    .writeByte(discriminator)
-                    .writeInt(4 + payload.readableBytes())
-                    .writeBytes(payload))
-            .reduce(TEST.buffer(), ByteBuf::writeBytes);
-
-        BackendMessageDecoder decoder = new BackendMessageDecoder(TEST);
-
-        assertThat(data.refCnt()).isOne();
-
-        return Flux.just(data.readRetainedSlice(data.readableBytes() / 2), data)
-            .concatMap(decoder::decode)
-            .delayUntil(release)
-            .doFinally(s -> decoder.dispose())
-            .doAfterTerminate(() -> assertThat(data.refCnt()).isZero())
-            .as(StepVerifier::create);
+    private BackendMessage decode(char discriminator, Function<ByteBuf, ByteBuf> decode) {
+        CompositeByteBuf data = TEST.compositeBuffer();
+        ByteBuf payload = decode.apply(TEST.buffer());
+        ByteBuf envelope = TEST.buffer(5 + payload.readableBytes())
+            .writeByte(discriminator)
+            .writeInt(4 + payload.readableBytes())
+            .writeBytes(payload);
+        payload.release();
+        data.addComponent(true, envelope);
+        return BackendMessageDecoder.decode(data);
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/message/backend/BackendMessageDecoderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/message/backend/BackendMessageDecoderTest.java
@@ -203,8 +203,8 @@ final class BackendMessageDecoderTest {
     @Test
     void dataRow() {
         decodeWithRelease('D', message -> Mono.fromRunnable(() -> {
-                ((DataRow) message).release();
                 assertThat(message).isEqualTo(new DataRow(Collections.singletonList(TEST.buffer(4).writeInt(100))));
+                ((DataRow) message).release();
             }),
             buffer -> buffer
                 .writeShort(1)
@@ -219,8 +219,8 @@ final class BackendMessageDecoderTest {
         decodeWithRelease('D', message -> Mono.just("test")
                 .delayElement(Duration.ofMillis(1))
                 .then(Mono.fromRunnable(() -> {
-                    ((DataRow) message).release();
                     assertThat(message).isEqualTo(new DataRow(Collections.singletonList(TEST.buffer(4).writeInt(100))));
+                    ((DataRow) message).release();
                 })),
             buffer -> buffer
                 .writeShort(1)
@@ -405,6 +405,8 @@ final class BackendMessageDecoderTest {
             .reduce(TEST.buffer(), ByteBuf::writeBytes);
 
         BackendMessageDecoder decoder = new BackendMessageDecoder(TEST);
+
+        assertThat(data.refCnt()).isOne();
 
         return Flux.just(data.readRetainedSlice(data.readableBytes() / 2), data)
             .concatMap(decoder::decode)

--- a/src/test/java/io/r2dbc/postgresql/message/backend/BackendMessageEnvelopeDecoderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/message/backend/BackendMessageEnvelopeDecoderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.message.backend;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.util.ReferenceCounted;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BackendMessageEnvelopeDecoderTest {
+
+    @Test
+    void testEmptyBuf() {
+        testSplit(
+            s -> s.verifyComplete(),
+            TEST.buffer());
+    }
+
+    @Test
+    void testCompleteEnvelope() {
+        testSplit(
+            s -> s
+                .expectNextCount(1)
+                .verifyComplete(),
+            envelope('R', buffer -> buffer.writeInt(3)));
+    }
+
+    @Test
+    void testMultipleEnvelopes() {
+        ByteBuf envelope = envelope('R', buffer -> buffer.writeInt(3));
+        CompositeByteBuf buf = TEST.compositeBuffer();
+        buf.writeBytes(envelope.slice());
+        buf.writeBytes(envelope.slice());
+        envelope.release();
+
+        testSplit(
+            s -> s
+                .expectNextCount(2)
+                .verifyComplete(),
+            buf);
+    }
+
+    @Test
+    void testPartialEnvelopes() {
+        ByteBuf envelope = envelope('R', buffer -> buffer.writeInt(3));
+        ByteBuf part1 = envelope.copy(0, 2);
+        ByteBuf part2 = envelope.copy(2, envelope.readableBytes() - 2)
+            .writeBytes(envelope.copy(0, 2));
+        ByteBuf part3 = envelope.copy(2, envelope.readableBytes() - 2);
+        envelope.release();
+
+        testSplit(
+            s -> s
+                .expectNextCount(2)
+                .verifyComplete(),
+            part1, part2, part3);
+
+    }
+
+    private ByteBuf envelope(char discriminator, Function<ByteBuf, ByteBuf> payloadWriter) {
+        ByteBuf payload = payloadWriter.apply(TEST.buffer());
+        ByteBuf envelope = TEST.buffer(5 + payload.readableBytes())
+            .writeByte(discriminator)
+            .writeInt(4 + payload.readableBytes())
+            .writeBytes(payload);
+        payload.release();
+        return envelope;
+    }
+
+    private void testSplit(Consumer<StepVerifier.FirstStep<CompositeByteBuf>> stepConsumer, ByteBuf... bufs) {
+        BackendMessageEnvelopeDecoder splitter = new BackendMessageEnvelopeDecoder(TEST);
+
+        stepConsumer.accept(Flux.just(bufs)
+            .concatMap(splitter)
+            .doOnNext(c -> assertThat(c.refCnt()).isOne())
+            .doOnNext(ReferenceCounted::release)
+            .as(StepVerifier::create));
+        splitter.dispose();
+        for (ByteBuf buf : bufs) {
+            assertThat(buf.refCnt()).isZero();
+        }
+    }
+}


### PR DESCRIPTION
CompositeByteBuf::discardReadComponents was called before mapping process in case of delayed mapping. 
Now we create new CompositeByteBuf from required parts for every envelope and that allows us to call discardReadComponents safe.

It should fix issues #107, #91 and #86.
#86 was tested with this [gist](https://gist.github.com/croudet/e34275f758765f7799b4870a45e8163d).
#107 was tested with this [gist](https://gist.github.com/flyaruu/239a950ffda6f3fc544faffffc866f12) and database from issue
#91 wasn't tested (need some help from someone with kotlin environment), but issue seems to be the same.