### PR TITLE
Support "postgres" driver

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -85,7 +85,7 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
         Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
 
         String driver = connectionFactoryOptions.getValue(DRIVER);
-        if (driver == null || !driver.equals(POSTGRESQL_DRIVER)) {
+        if (driver == null || !(driver.equals(POSTGRESQL_DRIVER) || driver.equals("postgres"))) {
             return false;
         }
 

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
@@ -90,4 +90,14 @@ final class PostgresqlConnectionFactoryProviderTest {
             .option(USER, "test-user")
             .build())).isTrue();
     }
+
+    @Test
+    void supportsPostgresDriver() {
+        assertThat(this.provider.supports(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "postgres")
+            .option(HOST, "test-host")
+            .option(PASSWORD, "test-password")
+            .option(USER, "test-user")
+            .build())).isTrue();
+    }
 }


### PR DESCRIPTION
As a Cloud Foundry user, I'd like to build a `ConnectionFactory` from [`DATABASE_URL`](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#DATABASE-URL) environment variable.

```java
ConnectionFactory connectionFactory = ConnectionFactories.get("r2dbc:" + System.getenv("DATABASE_URL"));
```


Currently r2dbc-postgresql supports only `postgresql` as a driver name but popular service brokers like elephantsql provides `postgres` schema like `postgres://exampleuser:examplepass@babar.elephantsql.com:5432/exampledb`

So, we need to replace `postgres` to `postgresql`

```java
ConnectionFactory connectionFactory = ConnectionFactories.get("r2dbc:" + System.getenv("DATABASE_URL").replace("postgres", "postgresql"));
```

It would be quite useful if r2dbc-postgresql accepts `postgres` and we can use `DATABASE_URL` directly.

