### PR TITLE
Fixed rollback behavior in case of transaction status OPEN or FAILED

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
@@ -171,7 +171,7 @@ public final class PostgresqlConnection implements Connection {
     @Override
     public Mono<Void> rollbackTransaction() {
         return useTransactionStatus(transactionStatus -> {
-            if (OPEN == transactionStatus) {
+            if (IDLE != transactionStatus) {
                 return SimpleQueryMessageFlow.exchange(this.client, "ROLLBACK")
                     .handle(PostgresqlExceptionFactory::handleErrorResponse);
             } else {
@@ -186,7 +186,7 @@ public final class PostgresqlConnection implements Connection {
         Assert.requireNonNull(name, "name must not be null");
 
         return useTransactionStatus(transactionStatus -> {
-            if (OPEN == transactionStatus) {
+            if (IDLE != transactionStatus) {
                 return SimpleQueryMessageFlow.exchange(this.client, String.format("ROLLBACK TO SAVEPOINT %s", name))
                     .handle(PostgresqlExceptionFactory::handleErrorResponse);
             } else {


### PR DESCRIPTION
This is a fix for ticket #139. It will not compile without the patches from branch stubbed-out-spi, so builds and test will fail prior to merging it. 