### PR TITLE
Add support for setting runtime parameters for new connections

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
@@ -28,6 +28,8 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.spi.ConnectionFactory;
 import reactor.core.publisher.Mono;
 
+import java.util.Map;
+
 /**
  * An implementation of {@link ConnectionFactory} for creating connections to a PostgreSQL database.
  */
@@ -61,7 +63,7 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
         return this.clientFactory
             .delayUntil(client ->
                 StartupMessageFlow
-                    .exchange(this.configuration.getApplicationName(), this::getAuthenticationHandler, client, this.configuration.getDatabase(), this.configuration.getUsername())
+                    .exchange(this.configuration.getApplicationName(), this::getAuthenticationHandler, client, this.configuration.getDatabase(), this.configuration.getUsername(), this.configuration.getOptions())
                     .handle(PostgresqlExceptionFactory::handleErrorResponse))
             .map(client -> new PostgresqlConnection(client, new DefaultCodecs(client.getByteBufAllocator()), DefaultPortalNameSupplier.INSTANCE, new IndefiniteStatementCache(client),
                 configuration.isForceBinary()))
@@ -71,6 +73,10 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
     @Override
     public PostgresqlConnectionFactoryMetadata getMetadata() {
         return PostgresqlConnectionFactoryMetadata.INSTANCE;
+    }
+
+    PostgresqlConnectionConfiguration getConfiguration() {
+        return this.configuration;
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -16,12 +16,19 @@
 
 package io.r2dbc.postgresql;
 
-import static io.r2dbc.spi.ConnectionFactoryOptions.*;
-
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
+import reactor.util.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static io.r2dbc.spi.ConnectionFactoryOptions.*;
 
 /**
  * An implementation of {@link ConnectionFactoryProvider} for creating {@link PostgresqlConnectionFactory}s.
@@ -48,6 +55,11 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
      */
     public static final Option<String> SCHEMA = Option.valueOf("schema");
 
+    /**
+     * Connection options which are applied once after the connection has been created.
+     */
+    public static final Option<Map<String, String>> OPTIONS = Option.valueOf("options");
+
     @Override
     public PostgresqlConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions) {
         Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
@@ -69,6 +81,11 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
         Integer port = connectionFactoryOptions.getValue(PORT);
         if (port != null) {
             builder.port(port);
+        }
+
+        Map<String, String> options = connectionFactoryOptions.getValue(OPTIONS);
+        if (options != null) {
+            builder.options(options);
         }
 
         return new PostgresqlConnectionFactory(builder.build());
@@ -97,7 +114,5 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
         }
 
         return connectionFactoryOptions.hasOption(USER);
-
     }
-
 }

--- a/src/main/java/io/r2dbc/postgresql/client/StartupMessageFlow.java
+++ b/src/main/java/io/r2dbc/postgresql/client/StartupMessageFlow.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.util.annotation.Nullable;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -47,11 +48,12 @@ public final class StartupMessageFlow {
      * @param client                        the {@link Client} to exchange messages with
      * @param database                      the database to connect to
      * @param username                      the username to authenticate with
+     * @param options                       the connection options
      * @return the messages received after authentication is complete, in response to this exchange
      * @throws IllegalArgumentException if {@code applicationName}, {@code authenticationHandler}, {@code client}, or {@code username} is {@code null}
      */
     public static Flux<BackendMessage> exchange(String applicationName, Function<AuthenticationMessage, AuthenticationHandler> authenticationHandlerProvider, Client client,
-                                                @Nullable String database, String username) {
+                                                @Nullable String database, String username, @Nullable Map<String, String> options) {
 
         Assert.requireNonNull(applicationName, "applicationName must not be null");
         Assert.requireNonNull(authenticationHandlerProvider, "authenticationHandlerProvider must not be null");
@@ -62,7 +64,7 @@ public final class StartupMessageFlow {
         FluxSink<FrontendMessage> requests = requestProcessor.sink();
         AtomicReference<AuthenticationHandler> authenticationHandler = new AtomicReference<>(null);
 
-        return client.exchange(requestProcessor.startWith(new StartupMessage(applicationName, database, username)))
+        return client.exchange(requestProcessor.startWith(new StartupMessage(applicationName, database, username, options)))
             .handle((message, sink) -> {
                 if (message instanceof AuthenticationOk) {
                     requests.complete();

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionConfigurationTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionConfigurationTest.java
@@ -19,6 +19,8 @@ package io.r2dbc.postgresql;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -51,11 +53,16 @@ final class PostgresqlConnectionConfigurationTest {
 
     @Test
     void configuration() {
+        Map<String, String> options = new HashMap<>();
+        options.put("lock_timeout", "10s");
+        options.put("statement_timeout", "60000"); // [ms]
+
         PostgresqlConnectionConfiguration configuration = PostgresqlConnectionConfiguration.builder()
             .applicationName("test-application-name")
             .connectTimeout(Duration.ofMillis(1000))
             .database("test-database")
             .host("test-host")
+            .options(options)
             .password("test-password")
             .port(100)
             .schema("test-schema")
@@ -67,6 +74,7 @@ final class PostgresqlConnectionConfigurationTest {
             .hasFieldOrPropertyWithValue("connectTimeout", Duration.ofMillis(1000))
             .hasFieldOrPropertyWithValue("database", "test-database")
             .hasFieldOrPropertyWithValue("host", "test-host")
+            .hasFieldOrPropertyWithValue("options", options)
             .hasFieldOrPropertyWithValue("password", "test-password")
             .hasFieldOrPropertyWithValue("port", 100)
             .hasFieldOrPropertyWithValue("schema", "test-schema")
@@ -118,6 +126,41 @@ final class PostgresqlConnectionConfigurationTest {
             .password("test-password")
             .build())
             .withMessage("username must not be null");
+    }
+
+    @Test
+    void constructorInvalidOptions() {
+        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlConnectionConfiguration.builder()
+            .host("test-host")
+            .username("test-username")
+            .password("test-password")
+            .options(null)
+            .build())
+            .withMessage("options map must not be null");
+
+        assertThatIllegalArgumentException().isThrownBy(() -> {
+            final Map<String, String> options = new HashMap<>();
+            options.put(null, "test-value");
+            PostgresqlConnectionConfiguration.builder()
+                    .host("test-host")
+                    .username("test-username")
+                    .password("test-password")
+                    .options(options)
+                    .build();
+                })
+                .withMessage("option keys must not be null");
+
+        assertThatIllegalArgumentException().isThrownBy(() -> {
+            final Map<String, String> options = new HashMap<>();
+            options.put("test-option", null);
+            PostgresqlConnectionConfiguration.builder()
+                    .host("test-host")
+                    .username("test-username")
+                    .password("test-password")
+                    .options(options)
+                    .build();
+                })
+                .withMessage("option values must not be null");
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
@@ -23,6 +23,9 @@ import static org.assertj.core.api.Assertions.*;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 final class PostgresqlConnectionFactoryProviderTest {
 
     private final PostgresqlConnectionFactoryProvider provider = new PostgresqlConnectionFactoryProvider();
@@ -97,4 +100,25 @@ final class PostgresqlConnectionFactoryProviderTest {
             .option(USER, "test-user")
             .build())).isTrue();
     }
+
+
+    @Test
+    void providerShouldparseAndHandleConnectionParameters() {
+        Map<String, String> expectedOptions = new HashMap<>();
+        expectedOptions.put("lock_timeout", "5s");
+        expectedOptions.put("statement_timeout", "6000");
+        PostgresqlConnectionFactory factory = this.provider.create(builder()
+                .option(DRIVER, LEGACY_POSTGRESQL_DRIVER)
+                .option(HOST, "test-host")
+                .option(PASSWORD, "test-password")
+                .option(USER, "test-user")
+                .option(OPTIONS, expectedOptions)
+                .build());
+
+        Map<String, String> actualOptions = factory.getConfiguration().getOptions();
+
+        assertThat(actualOptions).isNotNull();
+        assertThat(actualOptions).isEqualTo(expectedOptions);
+    }
+
 }

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryTest.java
@@ -62,7 +62,7 @@ final class PostgresqlConnectionFactoryTest {
         // @formatter:off
         Client client = TestClient.builder()
             .window()
-                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username")).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
+                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
                 .expectRequest(new PasswordMessage("md55e9836cdb369d50e3bc7d127e88b4804")).thenRespond(AuthenticationOk.INSTANCE)
                 .done()
             .build();
@@ -94,7 +94,7 @@ final class PostgresqlConnectionFactoryTest {
         // @formatter:off
         Client client = TestClient.builder()
             .window()
-                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username")).thenRespond(new AuthenticationSASL(Collections.singletonList("SCRAM-SHA-256")))
+                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(new AuthenticationSASL(Collections.singletonList("SCRAM-SHA-256")))
                 .expectRequest(new SASLInitialResponse(ByteBufferUtils.encode(scramClient.scramSession("test-username").clientFirstMessage()), "SCRAM-SHA-256")).thenRespond(AuthenticationOk.INSTANCE)
                 .done()
             .build();
@@ -114,7 +114,7 @@ final class PostgresqlConnectionFactoryTest {
         // @formatter:off
         Client client = TestClient.builder()
             .window()
-                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username")).thenRespond(new ErrorResponse(Collections.emptyList()))
+                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(new ErrorResponse(Collections.emptyList()))
                 .done()
             .build();
         // @formatter:on
@@ -137,7 +137,7 @@ final class PostgresqlConnectionFactoryTest {
         // @formatter:off
         Client client = TestClient.builder()
             .window()
-                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username")).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
+                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
                 .expectRequest(new PasswordMessage("md55e9836cdb369d50e3bc7d127e88b4804")).thenRespond(AuthenticationOk.INSTANCE)
                 .done()
             .build();

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionRuntimeOptionsTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionRuntimeOptionsTest.java
@@ -1,0 +1,53 @@
+package io.r2dbc.postgresql;
+
+import io.r2dbc.postgresql.util.PostgresqlServerExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import reactor.test.StepVerifier;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PostgresqlConnectionRuntimeOptionsTest {
+
+    @RegisterExtension
+    static final PostgresqlServerExtension SERVER = new PostgresqlServerExtension();
+
+    private static final Map<String, String> options = new HashMap<>();
+    static {
+        options.put("lock_timeout", "5000");
+        options.put("statement_timeout", "60s");
+    }
+
+    private final PostgresqlConnectionConfiguration configuration = PostgresqlConnectionConfiguration.builder()
+            .database(SERVER.getDatabase())
+            .host(SERVER.getHost())
+            .port(SERVER.getPort())
+            .password(SERVER.getPassword())
+            .username(SERVER.getUsername())
+            .forceBinary(true)
+            .options(options)
+            .build();
+
+    private final PostgresqlConnectionFactory connectionFactory = new PostgresqlConnectionFactory(this.configuration);
+
+    @Test void connectionFactoryShouldApplyParameters() {
+        PostgresqlConnection connection = connectionFactory.create().block();
+
+        connection
+                .createStatement("SHOW lock_timeout").execute()
+                .flatMap(result -> result.map((row, rowMetadata) -> row.get("lock_timeout", String.class)))
+                .as(StepVerifier::create)
+                .expectNext("5s")
+                .verifyComplete();
+
+        connection
+                .createStatement("SHOW statement_timeout").execute()
+                .flatMap(result -> result.map((row, rowMetadata) -> row.get("statement_timeout", String.class)))
+                .as(StepVerifier::create)
+                .expectNext("1min")
+                .verifyComplete();
+
+        connection.close().block();
+    }
+}

--- a/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientTest.java
+++ b/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientTest.java
@@ -50,7 +50,7 @@ final class ReactorNettyClientTest {
 
     private final ReactorNettyClient client = ReactorNettyClient.connect(SERVER.getHost(), SERVER.getPort())
         .delayUntil(client -> StartupMessageFlow
-            .exchange(this.getClass().getName(), m -> new PasswordAuthenticationHandler(SERVER.getPassword(), SERVER.getUsername()), client, SERVER.getDatabase(), SERVER.getUsername()))
+            .exchange(this.getClass().getName(), m -> new PasswordAuthenticationHandler(SERVER.getPassword(), SERVER.getUsername()), client, SERVER.getDatabase(), SERVER.getUsername(), SERVER.getOptions()))
         .block();
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/client/StartupMessageFlowTest.java
+++ b/src/test/java/io/r2dbc/postgresql/client/StartupMessageFlowTest.java
@@ -41,7 +41,7 @@ final class StartupMessageFlowTest {
         // @formatter:off
         Client client = TestClient.builder()
             .window()
-                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username")).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
+                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
                 .expectRequest(new PasswordMessage("test-password")).thenRespond(AuthenticationOk.INSTANCE)
                 .done()
             .build();
@@ -50,7 +50,7 @@ final class StartupMessageFlowTest {
         when(this.authenticationHandler.handle(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))).thenReturn(new PasswordMessage("test-password"));
 
         StartupMessageFlow
-            .exchange("test-application-name", m -> this.authenticationHandler, client, "test-database", "test-username")
+            .exchange("test-application-name", m -> this.authenticationHandler, client, "test-database", "test-username", null)
             .as(StepVerifier::create)
             .verifyComplete();
     }
@@ -58,13 +58,13 @@ final class StartupMessageFlowTest {
     @Test
     void exchangeAuthenticationMessageFail() {
         Client client = TestClient.builder()
-            .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username")).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
+            .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
             .build();
 
         when(this.authenticationHandler.handle(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))).thenThrow(new IllegalArgumentException());
 
         StartupMessageFlow
-            .exchange("test-application-name", m -> this.authenticationHandler, client, "test-database", "test-username")
+            .exchange("test-application-name", m -> this.authenticationHandler, client, "test-database", "test-username", null)
             .as(StepVerifier::create)
             .verifyError(IllegalArgumentException.class);
     }
@@ -72,11 +72,11 @@ final class StartupMessageFlowTest {
     @Test
     void exchangeAuthenticationOk() {
         Client client = TestClient.builder()
-            .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username")).thenRespond(AuthenticationOk.INSTANCE)
+            .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(AuthenticationOk.INSTANCE)
             .build();
 
         StartupMessageFlow
-            .exchange("test-application-name", m -> this.authenticationHandler, client, "test-database", "test-username")
+            .exchange("test-application-name", m -> this.authenticationHandler, client, "test-database", "test-username", null)
             .as(StepVerifier::create)
             .verifyComplete();
     }
@@ -84,11 +84,11 @@ final class StartupMessageFlowTest {
     @Test
     void exchangeAuthenticationOther() {
         Client client = TestClient.builder()
-            .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username")).thenRespond(AuthenticationOk.INSTANCE, new BackendKeyData(100, 200))
+            .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(AuthenticationOk.INSTANCE, new BackendKeyData(100, 200))
             .build();
 
         StartupMessageFlow
-            .exchange("test-application-name", m -> this.authenticationHandler, client, "test-database", "test-username")
+            .exchange("test-application-name", m -> this.authenticationHandler, client, "test-database", "test-username", null)
             .as(StepVerifier::create)
             .expectNext(new BackendKeyData(100, 200))
             .verifyComplete();
@@ -96,25 +96,25 @@ final class StartupMessageFlowTest {
 
     @Test
     void exchangeNoApplicationName() {
-        assertThatIllegalArgumentException().isThrownBy(() -> StartupMessageFlow.exchange(null, m -> this.authenticationHandler, NO_OP, "test-database", "test-username"))
+        assertThatIllegalArgumentException().isThrownBy(() -> StartupMessageFlow.exchange(null, m -> this.authenticationHandler, NO_OP, "test-database", "test-username", null))
             .withMessage("applicationName must not be null");
     }
 
     @Test
     void exchangeNoAuthenticationHandlerProvider() {
-        assertThatIllegalArgumentException().isThrownBy(() -> StartupMessageFlow.exchange("test-application-name", null, NO_OP, "test-database", "test-username"))
+        assertThatIllegalArgumentException().isThrownBy(() -> StartupMessageFlow.exchange("test-application-name", null, NO_OP, "test-database", "test-username", null))
             .withMessage("authenticationHandlerProvider must not be null");
     }
 
     @Test
     void exchangeNoClient() {
-        assertThatIllegalArgumentException().isThrownBy(() -> StartupMessageFlow.exchange("test-application-name", m -> this.authenticationHandler, null, "test-database", "test-username"))
+        assertThatIllegalArgumentException().isThrownBy(() -> StartupMessageFlow.exchange("test-application-name", m -> this.authenticationHandler, null, "test-database", "test-username", null))
             .withMessage("client must not be null");
     }
 
     @Test
     void exchangeNoUsername() {
-        assertThatIllegalArgumentException().isThrownBy(() -> StartupMessageFlow.exchange("test-application-name", m -> this.authenticationHandler, NO_OP, "test-database", null))
+        assertThatIllegalArgumentException().isThrownBy(() -> StartupMessageFlow.exchange("test-application-name", m -> this.authenticationHandler, NO_OP, "test-database", null, null))
             .withMessage("username must not be null");
     }
 

--- a/src/test/java/io/r2dbc/postgresql/message/frontend/StartupMessageTest.java
+++ b/src/test/java/io/r2dbc/postgresql/message/frontend/StartupMessageTest.java
@@ -28,19 +28,19 @@ final class StartupMessageTest {
 
     @Test
     void constructorNoApplicationName() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new StartupMessage(null, "test-database", "test-username"))
+        assertThatIllegalArgumentException().isThrownBy(() -> new StartupMessage(null, "test-database", "test-username", null))
             .withMessage("applicationName must not be null");
     }
 
     @Test
     void constructorNoUsername() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new StartupMessage("test-application-name", "test-database", null))
+        assertThatIllegalArgumentException().isThrownBy(() -> new StartupMessage("test-application-name", "test-database", null, null))
             .withMessage("username must not be null");
     }
 
     @Test
     void encode() {
-        assertThat(new StartupMessage("test-application-name", "test-database", "test-username")).encoded()
+        assertThat(new StartupMessage("test-application-name", "test-database", "test-username", null)).encoded()
             .isDeferred()
             .isEncodedAs(buffer -> {
                 buffer
@@ -97,7 +97,7 @@ final class StartupMessageTest {
 
     @Test
     void encodeNoDatabase() {
-        assertThat(new StartupMessage("test-application-name", null, "test-username")).encoded()
+        assertThat(new StartupMessage("test-application-name", null, "test-username", null)).encoded()
             .isDeferred()
             .isEncodedAs(buffer -> {
                 buffer

--- a/src/test/java/io/r2dbc/postgresql/util/PostgresqlServerExtension.java
+++ b/src/test/java/io/r2dbc/postgresql/util/PostgresqlServerExtension.java
@@ -26,6 +26,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import reactor.util.annotation.Nullable;
 
+import java.util.Map;
+
 public final class PostgresqlServerExtension implements BeforeAllCallback, AfterAllCallback {
 
     private final PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
@@ -81,4 +83,5 @@ public final class PostgresqlServerExtension implements BeforeAllCallback, After
         return this.container.getUsername();
     }
 
+    public Map<String, String> getOptions() { return null; }
 }


### PR DESCRIPTION
This PR adds optional parameters that will be applied to each new DB connection by the create() method.

Use case: You have a project that is using a PostgreSQL database server, you need some server parameters to be modified for your client (e.g. the lock_timeout parameter) and you can't or don't want to change the server config to achieve this (hello, AWS Aurora!). You wand to apply these parameters to each new connection. You are using a connection pool and so you don't even easily know if a connection is new or pooled. Plus, you don't want to write such code at all, maybe your code is just using spring boot repositories. 

Idea: This is the exact same scenario as how the default schema is applied. It can be set in the connection configuration and it is applied to each new connection. 

Implementation: The solution is similar to the implementation of the schema parameter, but using a key/value map.