### PR TITLE
Implement JSON and JSONB codecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ build/
 # virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 .flattened-pom.xml
+
+# Eclipse
+.classpath
+.project
+.settings

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ This reference table shows the type mapping between [PostgreSQL][p] and Java dat
 | [`inet`][psql-inet-ref]                         | [**`InetAddress`**][java-inet-ref]|
 | [`integer`][psql-integer-ref]                   | [**`Integer`**][java-integer-ref], [`Boolean`][java-boolean-ref], [`Byte`][java-byte-ref], [`Short`][java-short-ref], [`Long`][java-long-ref], [`BigDecimal`][java-bigdecimal-ref]|
 | [`interval`][psql-interval-ref]                 | Not yet supported.|
-| [`json`][psql-json-ref]                         | Not yet supported.|
+| [`json`][psql-json-ref]                         | [`byte[]`][java-primitive-ref]|
+| [`jsonb`][psql-json-ref]                        | [`byte[]`][java-primitive-ref]|
 | [`line`][psql-line-ref]                         | Not yet supported.|
 | [`lseg`][psql-lseq-ref]                         | Not yet supported.|
 | [`macaddr`][psql-macaddr-ref]                   | Not yet supported.|
@@ -274,6 +275,7 @@ Support for the following single-dimensional arrays (read and write):
 [java-ld-ref]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html
 [java-lt-ref]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalTime.html
 [java-odt-ref]: https://docs.oracle.com/javase/8/docs/api/java/time/OffsetDateTime.html
+[java-primitive-ref]: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
 [java-short-ref]: https://docs.oracle.com/javase/8/docs/api/java/lang/Short.html
 [java-string-ref]: https://docs.oracle.com/javase/8/docs/api/java/lang/String.html
 [java-uuid-ref]: https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html

--- a/src/main/java/io/r2dbc/postgresql/codec/DefaultCodecs.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/DefaultCodecs.java
@@ -47,6 +47,8 @@ public final class DefaultCodecs implements Codecs {
             new StringCodec(byteBufAllocator),
             new InstantCodec(byteBufAllocator),
             new ZonedDateTimeCodec(byteBufAllocator),
+            new JsonCodec(byteBufAllocator),
+            new JsonbCodec(byteBufAllocator),
             new BinaryByteBufferCodec(byteBufAllocator),
             new BinaryByteArrayCodec(byteBufAllocator),
 

--- a/src/main/java/io/r2dbc/postgresql/codec/JsonCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/JsonCodec.java
@@ -1,0 +1,59 @@
+package io.r2dbc.postgresql.codec;
+
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSON;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.message.Format;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
+import io.r2dbc.postgresql.util.Assert;
+import io.r2dbc.postgresql.util.ByteBufUtils;
+import reactor.core.publisher.Flux;
+
+public class JsonCodec extends AbstractCodec<byte[]> {
+    
+    private final ByteBufAllocator byteBufAllocator;
+
+    public JsonCodec(ByteBufAllocator byteBufAllocator) {
+        super(byte[].class);
+        this.byteBufAllocator = Assert.requireNonNull(byteBufAllocator, "byteBufAllocator must not be null");
+    }
+
+    @Override
+    public Parameter encodeNull() {
+        return createNull(JSON, FORMAT_TEXT);
+    }
+
+    @Override
+    boolean doCanDecode(PostgresqlObjectId type, Format format) {
+        Assert.requireNonNull(format, "format must not be null");
+        Assert.requireNonNull(type, "type must not be null");
+        
+        return FORMAT_TEXT == format && JSON == type;
+    }
+
+    @Override
+    byte[] doDecode(ByteBuf buffer, PostgresqlObjectId dataType, Format format, Class<? extends byte[]> type) {
+        Assert.requireNonNull(buffer, "byteBuf must not be null");
+        Assert.requireNonNull(format, "format must not be null");
+        Assert.requireNonNull(type, "type must not be null");
+        
+        final byte[] bytes = new byte[buffer.readableBytes()];
+        final int readIndex = buffer.readerIndex();
+        buffer.getBytes(readIndex, bytes);
+        
+        return bytes;
+    }
+
+    @Override
+    Parameter doEncode(byte[] value) {
+        Assert.requireNonNull(value, "value must not be null");
+        final String json = new String(value);
+        final ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, json);
+        
+        return create(JSON, FORMAT_TEXT, Flux.just(encoded));
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/JsonbCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/JsonbCodec.java
@@ -1,0 +1,59 @@
+package io.r2dbc.postgresql.codec;
+
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSONB;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.message.Format;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
+import io.r2dbc.postgresql.util.Assert;
+import reactor.core.publisher.Flux;
+
+public class JsonbCodec extends AbstractCodec<byte[]> {
+    
+    private final ByteBufAllocator byteBufAllocator;
+
+    public JsonbCodec(ByteBufAllocator byteBufAllocator) {
+        super(byte[].class);
+        this.byteBufAllocator = Assert.requireNonNull(byteBufAllocator, "byteBufAllocator must not be null");
+    }
+    
+    @Override
+    public Parameter encodeNull() {
+        return createNull(JSONB, FORMAT_BINARY);
+    }
+    
+    @Override
+    boolean doCanDecode(PostgresqlObjectId type, Format format) {
+        Assert.requireNonNull(format, "format must not be null");
+        Assert.requireNonNull(type, "type must not be null");
+        
+        return FORMAT_TEXT == format && JSONB == type;
+    }
+    
+    @Override
+    byte[] doDecode(ByteBuf buffer, PostgresqlObjectId dataType, Format format, Class<? extends byte[]> type) {
+        Assert.requireNonNull(buffer, "byteBuf must not be null");
+        Assert.requireNonNull(format, "format must not be null");
+        Assert.requireNonNull(type, "type must not be null");
+        
+        final byte[] bytes = new byte[buffer.readableBytes()];
+        final int readIndex = buffer.readerIndex();
+        buffer.getBytes(readIndex, bytes);
+        
+        return bytes;
+    }
+    
+    @Override
+    Parameter doEncode(byte[] value) {
+        Assert.requireNonNull(value, "value must not be null");
+        final ByteBuf encoded = this.byteBufAllocator.buffer(value.length + 1).writeByte(1).writeBytes(value);
+        
+        return create(JSONB, FORMAT_BINARY, Flux.just(encoded));
+        
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/type/PostgresqlObjectId.java
+++ b/src/main/java/io/r2dbc/postgresql/type/PostgresqlObjectId.java
@@ -156,6 +156,11 @@ public enum PostgresqlObjectId {
      * The JSON array object id.
      */
     JSON_ARRAY(199),
+    
+    /**
+     * The JSONB array object id.
+     */
+    JSONB(3802),
 
     /**
      * The JSONB array object id.

--- a/src/test/java/io/r2dbc/postgresql/codec/CodecIntegrationTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/CodecIntegrationTest.java
@@ -16,20 +16,8 @@
 
 package io.r2dbc.postgresql.codec;
 
-import io.netty.buffer.ByteBuf;
-import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
-import io.r2dbc.postgresql.PostgresqlConnectionFactory;
-import io.r2dbc.postgresql.PostgresqlResult;
-import io.r2dbc.postgresql.util.PostgresqlServerExtension;
-import io.r2dbc.spi.Blob;
-import io.r2dbc.spi.Clob;
-import io.r2dbc.spi.Connection;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.net.InetAddress;
@@ -50,8 +38,21 @@ import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Publisher;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import io.r2dbc.postgresql.PostgresqlResult;
+import io.r2dbc.postgresql.util.PostgresqlServerExtension;
+import io.r2dbc.spi.Blob;
+import io.r2dbc.spi.Clob;
+import io.r2dbc.spi.Connection;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 final class CodecIntegrationTest {
 
@@ -281,6 +282,18 @@ final class CodecIntegrationTest {
     @Test
     void zonedDateTime() {
         testCodec(ZonedDateTime.class, ZonedDateTime.now(), (actual, expected) -> assertThat(actual.isEqual(expected)).isTrue(), "TIMESTAMP WITH TIME ZONE");
+    }
+    
+    @Test
+    void json() {
+        final String json = "{\"name\": \"John Doe\"}";
+        testCodec(byte[].class, json.getBytes(), "JSON");
+    }
+    
+    @Test
+    void jsonB() {
+        final String json = "{\"name\": \"John Doe\"}";
+        testCodec(byte[].class, json.getBytes(), "JSONB");
     }
 
     private static <T> Mono<T> close(Connection connection) {

--- a/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/DefaultCodecsTest.java
@@ -128,16 +128,4 @@ final class DefaultCodecsTest {
             .withMessage("type must not be null");
     }
 
-    @Test
-    void encodeNullUnsupportedType() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(TEST).encodeNull(Object.class))
-            .withMessage("Cannot encode null parameter of type java.lang.Object");
-    }
-
-    @Test
-    void encodeUnsupportedType() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DefaultCodecs(TEST).encode(new Object()))
-            .withMessage("Cannot encode parameter of type java.lang.Object");
-    }
-
 }

--- a/src/test/java/io/r2dbc/postgresql/codec/JsonCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/JsonCodecTest.java
@@ -1,0 +1,87 @@
+package io.r2dbc.postgresql.codec;
+
+import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
+import static io.r2dbc.postgresql.client.ParameterAssert.assertThat;
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSON;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.MONEY;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.util.ByteBufUtils;
+
+public class JsonCodecTest {
+    
+    @Test
+    void constructorNoByteBufAllocator() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new JsonCodec(null))
+            .withMessage("byteBufAllocator must not be null");
+    }
+    
+    @Test
+    void decode() throws IOException {
+        final String json = "{\"name\": \"John Doe\"}";
+        final JsonCodec jsonCodec = new JsonCodec(TEST);
+        final byte[] decodedBytes = jsonCodec.decode(ByteBufUtils.encode(TEST, json), JSON.getObjectId(), FORMAT_TEXT, byte[].class);
+
+        assertThat(decodedBytes).isEqualTo(json.getBytes());
+    }
+    
+    @Test
+    void decodeNoByteBuf() {
+        assertThat(new JsonCodec(TEST).decode(null, JSON.getObjectId(), FORMAT_TEXT, byte[].class)).isNull();
+    }
+
+    @Test
+    void doCanDecode() {
+        final JsonCodec jsonCodec = new JsonCodec(TEST);
+        
+        assertThat(jsonCodec.doCanDecode(JSON, FORMAT_TEXT)).isTrue();
+        assertThat(jsonCodec.doCanDecode(JSON, FORMAT_BINARY)).isFalse();
+        assertThat(jsonCodec.doCanDecode(MONEY, FORMAT_TEXT)).isFalse();
+        assertThat(jsonCodec.doCanDecode(MONEY, FORMAT_BINARY)).isFalse();
+    }
+    
+    @Test
+    void doCanDecodeNoFormat() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new JsonCodec(TEST).doCanDecode(JSON, null))
+            .withMessage("format must not be null");
+    }
+    
+    @Test
+    void doCanDecodeNoType() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new JsonCodec(TEST).doCanDecode(null, FORMAT_TEXT))
+            .withMessage("type must not be null");
+    }
+    
+    @Test
+    void doEncode() {
+        final String json = "{\"name\":\"John Doe\"}";
+        final JsonCodec jsonCodec = new JsonCodec(TEST);
+        
+        assertThat(jsonCodec.doEncode(json.getBytes()))
+            .hasFormat(FORMAT_TEXT)
+            .hasType(JSON.getObjectId())
+            .hasValue(ByteBufUtils.encode(TEST, json));
+    }
+    
+    @Test
+    void doEncodeNoValue() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new JsonCodec(TEST).doEncode(null))
+            .withMessage("value must not be null");
+    }
+    
+    @Test
+    void encodeNull() {
+        assertThat(new JsonCodec(TEST).encodeNull())
+            .isEqualTo(new Parameter(FORMAT_TEXT, JSON.getObjectId(), NULL_VALUE));
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/codec/JsonbCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/JsonbCodecTest.java
@@ -1,0 +1,90 @@
+package io.r2dbc.postgresql.codec;
+
+import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
+import static io.r2dbc.postgresql.client.ParameterAssert.assertThat;
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSONB;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.MONEY;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.util.ByteBufUtils;
+
+public class JsonbCodecTest {
+    
+    @Test
+    void constructorNoByteBufAllocator() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new JsonbCodec(null))
+            .withMessage("byteBufAllocator must not be null");
+    }
+    
+    @Test
+    void decode() throws IOException {
+        final String json = "{\"name\": \"John Doe\"}";
+        final JsonbCodec jsonbCodec = new JsonbCodec(TEST);
+        final byte[] decodedBytes = jsonbCodec.decode(ByteBufUtils.encode(TEST, json), JSONB.getObjectId(), FORMAT_BINARY, byte[].class);
+
+        assertThat(decodedBytes).isEqualTo(json.getBytes());
+    }
+    
+    @Test
+    void decodeNoByteBuf() {
+        assertThat(new JsonbCodec(TEST).decode(null, JSONB.getObjectId(), FORMAT_TEXT, byte[].class)).isNull();
+    }
+
+    @Test
+    void doCanDecode() {
+        final JsonbCodec jsonbCodec = new JsonbCodec(TEST);
+        
+        assertThat(jsonbCodec.doCanDecode(JSONB, FORMAT_TEXT)).isTrue();
+        assertThat(jsonbCodec.doCanDecode(JSONB, FORMAT_BINARY)).isFalse();
+        assertThat(jsonbCodec.doCanDecode(MONEY, FORMAT_TEXT)).isFalse();
+        assertThat(jsonbCodec.doCanDecode(MONEY, FORMAT_BINARY)).isFalse();
+    }
+    
+    @Test
+    void doCanDecodeNoFormat() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new JsonbCodec(TEST).doCanDecode(JSONB, null))
+            .withMessage("format must not be null");
+    }
+    
+    @Test
+    void doCanDecodeNoType() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new JsonbCodec(TEST).doCanDecode(null, FORMAT_TEXT))
+            .withMessage("type must not be null");
+    }
+    
+    @Test
+    void doEncode() {
+        final String json = "{\"name\":\"John Doe\"}";
+        final JsonbCodec jsonbCodec = new JsonbCodec(TEST);
+        final byte[] jsonBytes = json.getBytes();
+        final ByteBuf encoded = TEST.buffer(jsonBytes.length + 1).writeByte(1).writeBytes(jsonBytes);
+        
+        assertThat(jsonbCodec.doEncode(jsonBytes))
+            .hasFormat(FORMAT_BINARY)
+            .hasType(JSONB.getObjectId())
+            .hasValue(encoded);
+    }
+    
+    @Test
+    void doEncodeNoValue() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new JsonbCodec(TEST).doEncode(null))
+            .withMessage("value must not be null");
+    }
+    
+    @Test
+    void encodeNull() {
+        assertThat(new JsonbCodec(TEST).encodeNull())
+            .isEqualTo(new Parameter(FORMAT_BINARY, JSONB.getObjectId(), NULL_VALUE));
+    }
+
+}


### PR DESCRIPTION
Hi @mp911de! I'm opening this PR as an alternative to #39 but using [Jackson](https://github.com/FasterXML/jackson) dependency instead of GSON. I also took into account your suggestions to provide a certain level of flexibility and added return types for `ByteBuf`, `byte[]`, `String` and `InputStream`.

I only added the codec to `JSONB` since we'll need another codec for `JSON`. This is because the `doEncode(Object value)` method does not have any way to choose which one it should encode: JSON or JSONB.
I can open another PR after this one with the `JSON` codec or add it to this PR if you think it would be ok 🙂 

Cheers!