### PR TITLE
Memory leak fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,9 @@
                         <include>**/*TestKit.java</include>
                         <include>**/*Test.java</include>
                     </includes>
+                    <systemPropertyVariables>
+                        <io.netty.leakDetectionLevel>paranoid</io.netty.leakDetectionLevel>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
@@ -73,10 +73,7 @@ public final class PostgresqlConnection implements Connection {
         this.statementCache = Assert.requireNonNull(statementCache, "statementCache must not be null");
         this.forceBinary = forceBinary;
         this.isolationLevel = Assert.requireNonNull(isolationLevel, "isolationLevel must not be null");
-        this.validationQuery = new SimpleQueryPostgresqlStatement(this.client, this.codecs, "SELECT 1")
-                .fetchSize(0)
-                .execute()
-                .flatMap(result -> result.map((row, meta) -> row.get(0, Integer.class)));
+        this.validationQuery = new SimpleQueryPostgresqlStatement(this.client, this.codecs, "SELECT 1").fetchSize(0).execute().flatMap(PostgresqlResult::getRowsUpdated);
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlResult.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlResult.java
@@ -59,6 +59,11 @@ public final class PostgresqlResult implements Result {
     public Mono<Integer> getRowsUpdated() {
 
         return this.messages
+            .doOnNext(message -> {
+                if (message instanceof DataRow) {
+                    ((DataRow) message).release();
+                }
+            })
             .ofType(CommandComplete.class)
             .singleOrEmpty()
             .handle((commandComplete, sink) -> {

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractArrayCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractArrayCodec.java
@@ -343,7 +343,7 @@ abstract class AbstractArrayCodec<T> extends AbstractCodec<Object[]> {
                     continue;
 
                 }
-                array[i] = decodeItem(buffer.readBytes(len));
+                array[i] = decodeItem(buffer.readSlice(len));
             }
         } else {
             for (int i = 0; i < dims[thisDimension]; ++i) {

--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractCodec.java
@@ -22,7 +22,10 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 import reactor.util.annotation.Nullable;
+
+import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
 
@@ -91,11 +94,15 @@ abstract class AbstractCodec<T> implements Codec<T> {
         return this.type;
     }
 
-    static Parameter create(PostgresqlObjectId type, Format format, @Nullable Publisher<? extends ByteBuf> value) {
+    static Parameter create(PostgresqlObjectId type, Format format, Publisher<? extends ByteBuf> value) {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
         return new Parameter(format, type.getObjectId(), value);
+    }
+
+    static Parameter create(PostgresqlObjectId type, Format format, Supplier<? extends ByteBuf> value) {
+        return new Parameter(format, type.getObjectId(), Mono.fromSupplier(value));
     }
 
     /**

--- a/src/main/java/io/r2dbc/postgresql/codec/BigDecimalCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BigDecimalCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.math.BigDecimal;
@@ -56,8 +55,7 @@ final class BigDecimalCodec extends AbstractNumericCodec<BigDecimal> {
     Parameter doEncode(BigDecimal value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.toString());
-        return create(NUMERIC, FORMAT_TEXT, Flux.just(encoded));
+        return create(NUMERIC, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/BlobCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BlobCodec.java
@@ -92,6 +92,7 @@ final class BlobCodec extends AbstractCodec<Blob> {
             buf.writeCharSequence(ByteBufUtil.hexDump(b, b.readerIndex(), chunkSize), StandardCharsets.US_ASCII);
             b.skipBytes(chunkSize);
         }
+        b.release();
 
         return buf;
     }

--- a/src/main/java/io/r2dbc/postgresql/codec/BooleanCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/BooleanCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -72,8 +71,7 @@ final class BooleanCodec extends AbstractCodec<Boolean> {
     Parameter doEncode(Boolean value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value ? "TRUE" : "FALSE");
-        return create(BOOL, FORMAT_TEXT, Flux.just(encoded));
+        return create(BOOL, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value ? "TRUE" : "FALSE"));
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/DoubleCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/DoubleCodec.java
@@ -22,7 +22,6 @@ import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
@@ -54,8 +53,7 @@ final class DoubleCodec extends AbstractNumericCodec<Double> {
     Parameter doEncode(Double value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = this.byteBufAllocator.buffer(8).writeDouble(value);
-        return create(FLOAT8, FORMAT_BINARY, Flux.just(encoded));
+        return create(FLOAT8, FORMAT_BINARY, () -> this.byteBufAllocator.buffer(8).writeDouble(value));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/FloatCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/FloatCodec.java
@@ -22,7 +22,6 @@ import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
@@ -54,8 +53,7 @@ final class FloatCodec extends AbstractNumericCodec<Float> {
     Parameter doEncode(Float value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = this.byteBufAllocator.buffer(4).writeFloat(value);
-        return create(FLOAT4, FORMAT_BINARY, Flux.just(encoded));
+        return create(FLOAT4, FORMAT_BINARY, () -> this.byteBufAllocator.buffer(4).writeFloat(value));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/InetAddressCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/InetAddressCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.net.InetAddress;
@@ -70,8 +69,7 @@ final class InetAddressCodec extends AbstractCodec<InetAddress> {
     Parameter doEncode(InetAddress value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.getHostAddress());
-        return create(VARCHAR, FORMAT_TEXT, Flux.just(encoded));
+        return create(VARCHAR, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.getHostAddress()));
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/InstantCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/InstantCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
@@ -71,8 +70,7 @@ final class InstantCodec extends AbstractTemporalCodec<Instant> {
     Parameter doEncode(Instant value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.toString());
-        return create(TIMESTAMP, FORMAT_TEXT, Flux.just(encoded));
+        return create(TIMESTAMP, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/IntegerCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/IntegerCodec.java
@@ -22,7 +22,6 @@ import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
@@ -54,8 +53,7 @@ final class IntegerCodec extends AbstractNumericCodec<Integer> {
     Parameter doEncode(Integer value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = this.byteBufAllocator.buffer(4).writeInt(value);
-        return create(INT4, FORMAT_BINARY, Flux.just(encoded));
+        return create(INT4, FORMAT_BINARY, () -> this.byteBufAllocator.buffer(4).writeInt(value));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/LocalDateCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/LocalDateCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
@@ -64,8 +63,7 @@ final class LocalDateCodec extends AbstractTemporalCodec<LocalDate> {
     Parameter doEncode(LocalDate value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.toString());
-        return create(DATE, FORMAT_TEXT, Flux.just(encoded));
+        return create(DATE, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/LocalDateTimeCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/LocalDateTimeCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
@@ -60,8 +59,7 @@ final class LocalDateTimeCodec extends AbstractTemporalCodec<LocalDateTime> {
     Parameter doEncode(LocalDateTime value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.toString());
-        return create(TIMESTAMP, FORMAT_TEXT, Flux.just(encoded));
+        return create(TIMESTAMP, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/LocalTimeCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/LocalTimeCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
@@ -65,8 +64,7 @@ final class LocalTimeCodec extends AbstractTemporalCodec<LocalTime> {
     Parameter doEncode(LocalTime value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.toString());
-        return create(TIME, FORMAT_TEXT, Flux.just(encoded));
+        return create(TIME, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/LongCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/LongCodec.java
@@ -22,8 +22,6 @@ import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
@@ -55,8 +53,7 @@ final class LongCodec extends AbstractNumericCodec<Long> {
     Parameter doEncode(Long value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = this.byteBufAllocator.buffer(8).writeLong(value);
-        return create(INT8, FORMAT_BINARY, Flux.just(encoded));
+        return create(INT8, FORMAT_BINARY, () -> this.byteBufAllocator.buffer(8).writeLong(value));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/OffsetDateTimeCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/OffsetDateTimeCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.time.OffsetDateTime;
@@ -56,8 +55,7 @@ final class OffsetDateTimeCodec extends AbstractTemporalCodec<OffsetDateTime> {
     Parameter doEncode(OffsetDateTime value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.toString());
-        return create(TIMESTAMPTZ, FORMAT_TEXT, Flux.just(encoded));
+        return create(TIMESTAMPTZ, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/ShortCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ShortCodec.java
@@ -22,7 +22,6 @@ import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
@@ -54,8 +53,7 @@ final class ShortCodec extends AbstractNumericCodec<Short> {
     Parameter doEncode(Short value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = this.byteBufAllocator.buffer(2).writeShort(value);
-        return create(INT2, FORMAT_BINARY, Flux.just(encoded));
+        return create(INT2, FORMAT_BINARY, () -> this.byteBufAllocator.buffer(2).writeShort(value));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/StringCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/StringCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
@@ -66,8 +65,7 @@ final class StringCodec extends AbstractCodec<String> {
     Parameter doEncode(String value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value);
-        return create(VARCHAR, FORMAT_TEXT, Flux.just(encoded));
+        return create(VARCHAR, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value));
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/UuidCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/UuidCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.util.UUID;
@@ -44,8 +43,7 @@ final class UuidCodec extends AbstractCodec<UUID> {
     public Parameter doEncode(UUID value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.toString());
-        return create(PostgresqlObjectId.UUID, FORMAT_TEXT, Flux.just(encoded));
+        return create(PostgresqlObjectId.UUID, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/ZonedDateTimeCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/ZonedDateTimeCodec.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
-import reactor.core.publisher.Flux;
 import reactor.util.annotation.Nullable;
 
 import java.time.ZonedDateTime;
@@ -56,8 +55,7 @@ final class ZonedDateTimeCodec extends AbstractTemporalCodec<ZonedDateTime> {
     Parameter doEncode(ZonedDateTime value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        ByteBuf encoded = ByteBufUtils.encode(this.byteBufAllocator, value.toOffsetDateTime().toString());
-        return create(TIMESTAMPTZ, FORMAT_TEXT, Flux.just(encoded));
+        return create(TIMESTAMPTZ, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toOffsetDateTime().toString()));
     }
 
     @Override

--- a/src/test/java/io/r2dbc/postgresql/codec/AbstractCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/AbstractCodecTest.java
@@ -19,6 +19,7 @@ package io.r2dbc.postgresql.codec;
 import io.r2dbc.postgresql.client.Parameter;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
 import static io.r2dbc.postgresql.client.ParameterAssert.assertThat;
@@ -96,13 +97,13 @@ final class AbstractCodecTest {
 
     @Test
     void createNoFormat() {
-        assertThatIllegalArgumentException().isThrownBy(() -> AbstractCodec.create(INT4, null, null))
+        assertThatIllegalArgumentException().isThrownBy(() -> AbstractCodec.create(INT4, null, Mono.empty()))
             .withMessage("format must not be null");
     }
 
     @Test
     void createNoType() {
-        assertThatIllegalArgumentException().isThrownBy(() -> AbstractCodec.create(null, FORMAT_TEXT, null))
+        assertThatIllegalArgumentException().isThrownBy(() -> AbstractCodec.create(null, FORMAT_TEXT, Mono.empty()))
             .withMessage("type must not be null");
     }
 

--- a/src/test/java/io/r2dbc/postgresql/codec/CodecIntegrationTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/CodecIntegrationTest.java
@@ -131,8 +131,8 @@ final class CodecIntegrationTest {
                 }
             },
             (actual, expected) -> Flux.zip(
-                Flux.from(actual.stream()).reduce(TEST.heapBuffer(), ByteBuf::writeBytes),
-                Flux.from(expected.stream()).reduce(TEST.heapBuffer(), ByteBuf::writeBytes)
+                Flux.from(actual.stream()).reduce(TEST.heapBuffer(), ByteBuf::writeBytes).concatWith(Mono.from(actual.discard()).then(Mono.empty())),
+                Flux.from(expected.stream()).reduce(TEST.heapBuffer(), ByteBuf::writeBytes).concatWith(Mono.from(expected.discard()).then(Mono.empty()))
             )
                 .as(StepVerifier::create)
                 .assertNext(t -> assertThat(t.getT1()).isEqualTo(t.getT2()))


### PR DESCRIPTION
There's still one leak in TestKit.batch method: since nobody subscribes on "SELECT value FROM test" result PostgresqlRow.data just leaks, but I'm not sure is that a leak in a driver or wrong api usage.
Test can be written like this to prevent leak.
```java
@Test
default void batch() {
    getJdbcOperations().execute("INSERT INTO test VALUES (100)");

    Mono.from(getConnectionFactory().create())
        .flatMapMany(connection -> Flux.from(connection
            .createBatch()
            .add("INSERT INTO test VALUES(200)")
            .add("SELECT value FROM test")
            .execute())
            .concatWith(Mono.from(connection.close()).then(Mono.empty())))
        .as(StepVerifier::create)
        .consumeNextWith(r -> Mono.from(r.getRowsUpdated()).subscribe())
        .consumeNextWith(r -> Flux.from(r.map((row, meta) -> row.get(0))).subscribe())
        .verifyComplete();
}
```