### PR TITLE
Draft for logical decoding

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresReplicationStream.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresReplicationStream.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
+import io.r2dbc.postgresql.message.backend.BackendMessage;
+import io.r2dbc.postgresql.message.backend.CopyData;
+import io.r2dbc.postgresql.message.backend.ReadyForQuery;
+import io.r2dbc.postgresql.message.frontend.CopyDone;
+import io.r2dbc.postgresql.message.frontend.FrontendMessage;
+import io.r2dbc.postgresql.replication.LogSequenceNumber;
+import io.r2dbc.postgresql.replication.ReplicationRequest;
+import io.r2dbc.postgresql.replication.ReplicationStream;
+import io.r2dbc.postgresql.util.Assert;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import reactor.core.Disposable;
+import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+final class PostgresReplicationStream implements ReplicationStream {
+
+    public static final long POSTGRES_EPOCH_2000_01_01 = 946684800000L;
+
+    private final EmitterProcessor<CopyData> responseProcessor = EmitterProcessor.create(false);
+
+    private final EmitterProcessor<FrontendMessage> requestProcessor;
+
+    private final AtomicReference<Disposable> subscription = new AtomicReference<>();
+
+    private final ByteBufAllocator allocator;
+
+    private final ReplicationRequest replicationRequest;
+
+    private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+    private volatile LogSequenceNumber lastServerLSN = LogSequenceNumber.INVALID_LSN;
+
+    private volatile LogSequenceNumber lastReceiveLSN = LogSequenceNumber.INVALID_LSN;
+
+    private volatile LogSequenceNumber lastAppliedLSN = LogSequenceNumber.INVALID_LSN;
+
+    private volatile LogSequenceNumber lastFlushedLSN = LogSequenceNumber.INVALID_LSN;
+
+    PostgresReplicationStream(ByteBufAllocator allocator, ReplicationRequest replicationRequest, EmitterProcessor<FrontendMessage> requestProcessor, Flux<BackendMessage> messages) {
+        this.allocator = allocator;
+        this.replicationRequest = replicationRequest;
+        this.requestProcessor = requestProcessor;
+
+        Flux<CopyData> stream = messages
+            .takeUntil(ReadyForQuery.class::isInstance)
+            .doOnError(throwable -> {
+                close().subscribe();
+                this.closeFuture.complete(null);
+            })
+            .doOnComplete(() -> {
+                this.closeFuture.complete(null);
+            })
+            .ofType(CopyData.class)
+            .handle((message, sink) -> {
+
+                try {
+
+                    byte code = message.getData().readByte();
+
+                    switch (code) {
+
+                        case 'k': //KeepAlive message
+                            boolean updateStatusRequired = processKeepAliveMessage(message.getData());
+                            updateStatusRequired |= this.replicationRequest.getStatusInterval().isZero();
+                            if (updateStatusRequired) {
+                                sendStatusUpdate();
+                            }
+                            return;
+
+                        case 'w': //XLogData
+                            processXLogData(message.getData());
+                            message.retain();
+                            sink.next(message);
+                            return;
+
+                        default:
+                            sink.error(new R2dbcNonTransientResourceException(String.format("Unexpected packet type during replication: %s", Integer.toString(code))));
+                    }
+                } finally {
+                    ReferenceCountUtil.release(message);
+                }
+            });
+
+        stream.subscribeWith(this.responseProcessor);
+        Disposable disposable = () -> {
+        };
+
+        Duration statusInterval = replicationRequest.getStatusInterval();
+        if (!statusInterval.isZero()) {
+
+            Scheduler.Worker worker = Schedulers.parallel().createWorker();
+
+            worker.schedulePeriodically(this::sendStatusUpdate, statusInterval.toMillis(), statusInterval.toMillis(), TimeUnit.MILLISECONDS);
+
+            disposable = worker;
+        }
+
+        this.subscription.set(disposable);
+    }
+
+    private boolean processKeepAliveMessage(ByteBuf buffer) {
+
+        this.lastServerLSN = LogSequenceNumber.valueOf(buffer.readLong());
+        if (this.lastServerLSN.asLong() > this.lastReceiveLSN.asLong()) {
+            this.lastReceiveLSN = this.lastServerLSN;
+        }
+
+        long lastServerClock = buffer.readLong();
+        boolean replyRequired = buffer.readByte() != 0;
+
+        return replyRequired;
+    }
+
+    private void processXLogData(ByteBuf buffer) {
+
+        long startLsn = buffer.readLong();
+        this.lastServerLSN = LogSequenceNumber.valueOf(buffer.readLong());
+        long systemClock = buffer.readLong();
+
+        switch (this.replicationRequest.getReplicationType()) {
+            case LOGICAL:
+                this.lastReceiveLSN = LogSequenceNumber.valueOf(startLsn);
+                break;
+            case PHYSICAL:
+                int payloadSize = buffer.readableBytes() - buffer.readerIndex();
+                this.lastReceiveLSN = LogSequenceNumber.valueOf(startLsn + payloadSize);
+                break;
+        }
+    }
+
+    private void sendStatusUpdate() {
+        ByteBuf byteBuf = prepareUpdateStatus(this.lastReceiveLSN, this.lastFlushedLSN, this.lastAppliedLSN, false);
+        io.r2dbc.postgresql.message.frontend.CopyData copyData = new io.r2dbc.postgresql.message.frontend.CopyData(byteBuf);
+        this.requestProcessor.onNext(copyData);
+    }
+
+    private ByteBuf prepareUpdateStatus(LogSequenceNumber received, LogSequenceNumber flushed,
+                                        LogSequenceNumber applied, boolean replyRequired) {
+        ByteBuf byteBuffer = this.allocator.buffer(34);
+
+        long now = System.currentTimeMillis();
+        long systemClock = TimeUnit.MICROSECONDS.convert((now - POSTGRES_EPOCH_2000_01_01),
+            TimeUnit.MICROSECONDS);
+
+        byteBuffer.writeByte((byte) 'r');
+        byteBuffer.writeLong(received.asLong());
+        byteBuffer.writeLong(flushed.asLong());
+        byteBuffer.writeLong(applied.asLong());
+        byteBuffer.writeLong(systemClock);
+        if (replyRequired) {
+            byteBuffer.writeByte((byte) 1);
+        } else {
+            byteBuffer.writeByte(received == LogSequenceNumber.INVALID_LSN ? (byte) 1 : (byte) 0);
+        }
+
+        return byteBuffer;
+    }
+
+    @Override
+    public Mono<Void> close() {
+
+        Disposable disposable = this.subscription.get();
+        if (disposable != null && this.subscription.compareAndSet(disposable, null)) {
+            disposable.dispose();
+
+            this.requestProcessor.onNext(CopyDone.INSTANCE);
+            this.requestProcessor.onComplete();
+
+            return this.responseProcessor.ignoreElements().then(Mono.fromCompletionStage(this.closeFuture));
+        }
+
+        return Mono.fromCompletionStage(this.closeFuture);
+    }
+
+    @Override
+    public boolean isClosed() {
+        return this.subscription.get() == null;
+    }
+
+    @Override
+    public <T> Flux<T> map(Function<ByteBuf, ? extends T> mappingFunction) {
+        Assert.requireNonNull(mappingFunction, "mappingFunction must not be null");
+        return this.responseProcessor.map(data -> {
+
+            try {
+                return mappingFunction.apply(data.getData());
+            } finally {
+                ReferenceCountUtil.release(data);
+            }
+        });
+    }
+
+    @Override
+    public LogSequenceNumber getLastReceiveLSN() {
+        return this.lastReceiveLSN;
+    }
+
+    @Override
+    public LogSequenceNumber getLastFlushedLSN() {
+        return this.lastFlushedLSN;
+    }
+
+    @Override
+    public LogSequenceNumber getLastAppliedLSN() {
+        return this.lastAppliedLSN;
+    }
+
+    @Override
+    public void setFlushedLSN(LogSequenceNumber flushed) {
+        this.lastFlushedLSN = flushed;
+    }
+
+    @Override
+    public void setAppliedLSN(LogSequenceNumber applied) {
+        this.lastAppliedLSN = applied;
+    }
+}

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
@@ -79,6 +79,10 @@ final class PostgresqlConnection implements io.r2dbc.postgresql.api.PostgresqlCo
         this.validationQuery = new SimpleQueryPostgresqlStatement(this.client, this.codecs, "SELECT 1").fetchSize(0).execute().flatMap(PostgresqlResult::getRowsUpdated);
     }
 
+    Client getClient() {
+        return this.client;
+    }
+
     @Override
     public Mono<Void> beginTransaction() {
         return useTransactionStatus(transactionStatus -> {

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
@@ -37,10 +37,13 @@ import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -48,6 +51,10 @@ import java.util.function.Predicate;
  * An implementation of {@link ConnectionFactory} for creating connections to a PostgreSQL database.
  */
 public final class PostgresqlConnectionFactory implements ConnectionFactory {
+
+    private static final String REPLICATION_OPTION = "replication";
+
+    private static final String REPLICATION_DATABASE = "database";
 
     private final Function<SSLConfig, Mono<? extends Client>> clientFactory;
 
@@ -85,12 +92,43 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
 
     @Override
     public Mono<io.r2dbc.postgresql.api.PostgresqlConnection> create() {
+
+        boolean forReplication = isReplicationConnection();
+        if (forReplication) {
+            throw new UnsupportedOperationException("Cannot create replication connection through create(). Use replication() method instead.");
+        }
+
+        return doCreateConnection(false, this.configuration.getOptions()).cast(io.r2dbc.postgresql.api.PostgresqlConnection.class);
+    }
+
+    /**
+     * Creates a new {@link io.r2dbc.postgresql.api.PostgresqlReplicationConnection} for interaction with replication streams.
+     *
+     * @return a new {@link io.r2dbc.postgresql.api.PostgresqlReplicationConnection} for interaction with replication streams.
+     * TODO: Better name
+     */
+    public Mono<io.r2dbc.postgresql.api.PostgresqlReplicationConnection> replication() {
+
+        Map<String, String> options = this.configuration.getOptions();
+        if (options == null) {
+            options = new HashMap<>();
+        } else {
+            options = new HashMap<>(options);
+        }
+
+        options.put(REPLICATION_OPTION, REPLICATION_DATABASE);
+
+        return doCreateConnection(true, options).map(PostgresqlReplicationConnection::new);
+    }
+
+    private Mono<PostgresqlConnection> doCreateConnection(boolean forReplication, @Nullable Map<String, String> options) {
+
         SSLConfig sslConfig = this.configuration.getSslConfig();
         Predicate<Throwable> isAuthSpecificationError = e -> e instanceof ExceptionFactory.PostgresqlAuthenticationFailure;
-        return this.tryConnectWithConfig(sslConfig)
+        return this.tryConnectWithConfig(sslConfig, options)
             .onErrorResume(
                 isAuthSpecificationError.and(e -> sslConfig.getSslMode() == SSLMode.ALLOW),
-                e -> this.tryConnectWithConfig(sslConfig.mutateMode(SSLMode.REQUIRE))
+                e -> this.tryConnectWithConfig(sslConfig.mutateMode(SSLMode.REQUIRE), options)
                     .onErrorResume(sslAuthError -> {
                         e.addSuppressed(sslAuthError);
                         return Mono.error(e);
@@ -98,7 +136,7 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
             )
             .onErrorResume(
                 isAuthSpecificationError.and(e -> sslConfig.getSslMode() == SSLMode.PREFER),
-                e -> this.tryConnectWithConfig(sslConfig.mutateMode(SSLMode.DISABLE))
+                e -> this.tryConnectWithConfig(sslConfig.mutateMode(SSLMode.DISABLE), options)
                     .onErrorResume(sslAuthError -> {
                         e.addSuppressed(sslAuthError);
                         return Mono.error(e);
@@ -107,20 +145,30 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
             .flatMap(client -> {
                 DefaultCodecs codecs = new DefaultCodecs(client.getByteBufAllocator());
 
-                return this.getIsolationLevel(client, codecs)
+                Mono<IsolationLevel> isolationLevelMono = Mono.just(IsolationLevel.READ_COMMITTED);
+                if (!forReplication) {
+                    isolationLevelMono = getIsolationLevel(client, codecs);
+                }
+
+                return isolationLevelMono
                     .map(it -> new PostgresqlConnection(client, codecs, DefaultPortalNameSupplier.INSTANCE, new IndefiniteStatementCache(client), it, this.configuration.isForceBinary()))
                     .delayUntil(connection -> {
                         return prepareConnection(connection, client.getByteBufAllocator(), codecs);
                     })
                     .onErrorResume(throwable -> this.closeWithError(client, throwable));
-            }).onErrorMap(this::cannotConnect).cast(io.r2dbc.postgresql.api.PostgresqlConnection.class);
+            }).onErrorMap(this::cannotConnect);
     }
 
-    private Mono<Client> tryConnectWithConfig(SSLConfig sslConfig) {
+    private boolean isReplicationConnection() {
+        Map<String, String> options = this.configuration.getOptions();
+        return options != null && REPLICATION_DATABASE.equalsIgnoreCase(options.get(REPLICATION_OPTION));
+    }
+
+    private Mono<Client> tryConnectWithConfig(SSLConfig sslConfig, @Nullable Map<String, String> options) {
         return this.clientFactory.apply(sslConfig)
             .delayUntil(client -> StartupMessageFlow
                 .exchange(this.configuration.getApplicationName(), this::getAuthenticationHandler, client, this.configuration.getDatabase(), this.configuration.getUsername(),
-                    this.configuration.getOptions())
+                    options)
                 .handle(ExceptionFactory.INSTANCE::handleErrorResponse))
             .cast(Client.class);
     }

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlReplicationConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlReplicationConnection.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.r2dbc.postgresql.api.PostgresqlConnectionMetadata;
+import io.r2dbc.postgresql.client.Client;
+import io.r2dbc.postgresql.message.backend.BackendMessage;
+import io.r2dbc.postgresql.message.backend.EmptyQueryResponse;
+import io.r2dbc.postgresql.message.backend.ErrorResponse;
+import io.r2dbc.postgresql.message.backend.ReadyForQuery;
+import io.r2dbc.postgresql.message.frontend.FrontendMessage;
+import io.r2dbc.postgresql.message.frontend.Query;
+import io.r2dbc.postgresql.replication.LogSequenceNumber;
+import io.r2dbc.postgresql.replication.ReplicationRequest;
+import io.r2dbc.postgresql.replication.ReplicationSlot;
+import io.r2dbc.postgresql.replication.ReplicationSlotRequest;
+import io.r2dbc.postgresql.replication.ReplicationStream;
+import io.r2dbc.postgresql.util.Assert;
+import io.r2dbc.spi.Row;
+import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Predicate;
+
+import static io.r2dbc.postgresql.util.PredicateUtils.or;
+
+/**
+ * Postgres replication connection.
+ */
+final class PostgresqlReplicationConnection implements io.r2dbc.postgresql.api.PostgresqlReplicationConnection {
+
+    private static final Predicate<BackendMessage> WINDOW_UNTIL = or(ReadyForQuery.class::isInstance, EmptyQueryResponse.class::isInstance, ErrorResponse.class::isInstance);
+
+    private final PostgresqlConnection delegate;
+
+    private final Client client;
+
+    public PostgresqlReplicationConnection(PostgresqlConnection delegate) {
+        this.delegate = delegate;
+        this.client = delegate.getClient();
+    }
+
+    @Override
+    public Mono<Void> close() {
+        return this.delegate.close();
+    }
+
+    @Override
+    public Mono<ReplicationSlot> createSlot(ReplicationSlotRequest request) {
+
+        Assert.requireNonNull(request, "request must not be null");
+
+        return this.delegate.createStatement(request.asSQL()).execute().flatMap(it -> {
+
+            return it.map((row, rowMetadata) -> {
+
+                return new ReplicationSlot(
+                    getString(row, "slot_name"),
+                    request.getReplicationType(),
+                    LogSequenceNumber.valueOf(getString(row, "consistent_point")),
+                    row.get("snapshot_name", String.class),
+                    row.get("output_plugin", String.class));
+            });
+        }).last();
+    }
+
+    @Override
+    public Mono<ReplicationStream> startReplication(ReplicationRequest request) {
+
+        Assert.requireNonNull(request, "request must not be null");
+
+        String sql = request.asSQL();
+        ExceptionFactory exceptionFactory = ExceptionFactory.withSql(sql);
+
+        EmitterProcessor<FrontendMessage> requestProcessor = EmitterProcessor.create();
+
+        return Mono.fromDirect(this.client.exchange(requestProcessor.startWith(new Query(sql)))
+            .handle(exceptionFactory::handleErrorResponse)
+            .windowUntil(WINDOW_UNTIL)
+            .map(messages -> {
+                return new PostgresReplicationStream(this.client.getByteBufAllocator(), request, requestProcessor, messages);
+            }));
+    }
+
+    @Override
+    public PostgresqlConnectionMetadata getMetadata() {
+        return this.delegate.getMetadata();
+    }
+
+    private static String getString(Row row, String column) {
+        String value = row.get(column, String.class);
+        if (value == null) {
+            throw new IllegalStateException(String.format("No value found for column %s", column));
+        }
+        return value;
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlResult.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlResult.java
@@ -16,6 +16,7 @@
 
 package io.r2dbc.postgresql;
 
+import io.netty.util.ReferenceCountUtil;
 import io.r2dbc.postgresql.codec.Codecs;
 import io.r2dbc.postgresql.message.backend.BackendMessage;
 import io.r2dbc.postgresql.message.backend.CommandComplete;
@@ -59,11 +60,7 @@ final class PostgresqlResult implements io.r2dbc.postgresql.api.PostgresqlResult
     public Mono<Integer> getRowsUpdated() {
 
         return this.messages
-            .doOnNext(message -> {
-                if (message instanceof DataRow) {
-                    ((DataRow) message).release();
-                }
-            })
+            .doOnNext(ReferenceCountUtil::release)
             .ofType(CommandComplete.class)
             .singleOrEmpty()
             .handle((commandComplete, sink) -> {
@@ -83,20 +80,22 @@ final class PostgresqlResult implements io.r2dbc.postgresql.api.PostgresqlResult
         return this.messages.takeUntil(TAKE_UNTIL)
             .handle((message, sink) -> {
 
-                if (message instanceof RowDescription) {
-                    this.rowDescription = (RowDescription) message;
-                    this.metadata = PostgresqlRowMetadata.toRowMetadata(this.codecs, (RowDescription) message);
-                    return;
-                }
-
-                if (message instanceof DataRow) {
-                    PostgresqlRow row = PostgresqlRow.toRow(this.codecs, (DataRow) message, this.rowDescription);
-
-                    try {
-                        sink.next(f.apply(row, this.metadata));
-                    } finally {
-                        row.release();
+                try {
+                    if (message instanceof RowDescription) {
+                        this.rowDescription = (RowDescription) message;
+                        this.metadata = PostgresqlRowMetadata.toRowMetadata(this.codecs, (RowDescription) message);
+                        return;
                     }
+
+                    if (message instanceof DataRow) {
+                        PostgresqlRow row = PostgresqlRow.toRow(this.codecs, (DataRow) message, this.rowDescription);
+
+
+                        sink.next(f.apply(row, this.metadata));
+                    }
+
+                } finally {
+                    ReferenceCountUtil.release(message);
                 }
             });
     }

--- a/src/main/java/io/r2dbc/postgresql/api/PostgresqlReplicationConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/api/PostgresqlReplicationConnection.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.api;
+
+import io.r2dbc.postgresql.replication.ReplicationRequest;
+import io.r2dbc.postgresql.replication.ReplicationSlot;
+import io.r2dbc.postgresql.replication.ReplicationSlotRequest;
+import io.r2dbc.postgresql.replication.ReplicationStream;
+import io.r2dbc.spi.Closeable;
+import reactor.core.publisher.Mono;
+
+/**
+ * A PostgreSQL replication connection.
+ */
+public interface PostgresqlReplicationConnection extends Closeable {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    Mono<Void> close();
+
+    /**
+     * Creates a replication slot for logical or physical replication.
+     *
+     * @param request description of the slot to create.
+     * @return {@link Mono} emitting {@link ReplicationSlot} information once the slot was created.
+     */
+    Mono<ReplicationSlot> createSlot(ReplicationSlotRequest request);
+
+    /**
+     * Starts the {@link ReplicationStream} for logical or physical replication.
+     * After starting the replication stream this connection becomes unavailable for slot creation and other streams unless the {@link ReplicationStream} is {@link ReplicationStream#close() closed}.
+     *
+     * @param request description of the replication stream to create.
+     * @return {@link Mono} emitting {@link ReplicationStream} once the replication was started.
+     */
+    Mono<ReplicationStream> startReplication(ReplicationRequest request);
+
+    /**
+     * Returns the {@link PostgresqlConnectionMetadata} for this connection.
+     *
+     * @return the {@link PostgresqlConnectionMetadata} for this connection.
+     */
+    PostgresqlConnectionMetadata getMetadata();
+
+}

--- a/src/main/java/io/r2dbc/postgresql/message/backend/CopyData.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/CopyData.java
@@ -17,18 +17,17 @@
 package io.r2dbc.postgresql.message.backend;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.AbstractReferenceCounted;
 import io.r2dbc.postgresql.util.Assert;
-import io.r2dbc.postgresql.util.ByteBufferUtils;
 
-import java.nio.ByteBuffer;
 import java.util.Objects;
 
 /**
  * The CopyData message.
  */
-public final class CopyData implements BackendMessage {
+public final class CopyData extends AbstractReferenceCounted implements BackendMessage {
 
-    private final ByteBuffer data;
+    private final ByteBuf data;
 
     /**
      * Creates a new message.
@@ -39,7 +38,7 @@ public final class CopyData implements BackendMessage {
     public CopyData(ByteBuf data) {
         Assert.requireNonNull(data, "data must not be null");
 
-        this.data = ByteBufferUtils.toByteBuffer(data);
+        this.data = data;
     }
 
     @Override
@@ -59,7 +58,7 @@ public final class CopyData implements BackendMessage {
      *
      * @return data that forms part of a {@code COPY} data stream.
      */
-    public ByteBuffer getData() {
+    public ByteBuf getData() {
         return this.data;
     }
 
@@ -73,6 +72,16 @@ public final class CopyData implements BackendMessage {
         return "CopyData{" +
             "data=" + this.data +
             '}';
+    }
+
+    @Override
+    protected void deallocate() {
+        this.data.release();
+    }
+
+    @Override
+    public CopyData touch(Object hint) {
+        return this;
     }
 
     static CopyData decode(ByteBuf in) {

--- a/src/main/java/io/r2dbc/postgresql/message/backend/DataRow.java
+++ b/src/main/java/io/r2dbc/postgresql/message/backend/DataRow.java
@@ -17,6 +17,7 @@
 package io.r2dbc.postgresql.message.backend;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.AbstractReferenceCounted;
 import io.r2dbc.postgresql.util.Assert;
 import reactor.util.annotation.Nullable;
 
@@ -25,7 +26,7 @@ import java.util.Arrays;
 /**
  * The DataRow message.
  */
-public final class DataRow implements BackendMessage {
+public final class DataRow extends AbstractReferenceCounted implements BackendMessage {
 
     private static final int NULL = -1;
 
@@ -67,10 +68,16 @@ public final class DataRow implements BackendMessage {
         return Arrays.hashCode(this.columns);
     }
 
-    /**
-     * Release the data encapsulated by the message.
-     */
-    public void release() {
+    @Override
+    public String toString() {
+        return "DataRow{" +
+            "columns=" + Arrays.toString(this.columns) +
+            '}';
+    }
+
+    @Override
+    protected void deallocate() {
+
         for (ByteBuf column : this.columns) {
             if (column != null) {
                 column.release();
@@ -79,10 +86,8 @@ public final class DataRow implements BackendMessage {
     }
 
     @Override
-    public String toString() {
-        return "DataRow{" +
-            "columns=" + Arrays.toString(this.columns) +
-            '}';
+    public DataRow touch(Object hint) {
+        return this;
     }
 
     static DataRow decode(ByteBuf in) {

--- a/src/main/java/io/r2dbc/postgresql/replication/LogSequenceNumber.java
+++ b/src/main/java/io/r2dbc/postgresql/replication/LogSequenceNumber.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+import java.util.Objects;
+
+/**
+ * LSN (Log Sequence Number). The value represents a pointer to a location in the XLOG.
+ */
+public final class LogSequenceNumber implements Comparable<LogSequenceNumber> {
+
+    /**
+     * Zero is used indicate an invalid pointer. Bootstrap skips the first possible WAL segment,
+     * initializing the first WAL page at XLOG_SEG_SIZE, so no XLOG record can begin at zero.
+     */
+    public static final LogSequenceNumber INVALID_LSN = LogSequenceNumber.valueOf(0);
+
+    private final long value;
+
+    private LogSequenceNumber(long value) {
+        this.value = value;
+    }
+
+    /**
+     * @param value numeric represent position in the write-ahead log stream
+     * @return not null LSN instance
+     */
+    public static LogSequenceNumber valueOf(long value) {
+        return new LogSequenceNumber(value);
+    }
+
+    /**
+     * Create LSN instance by string represent LSN.
+     *
+     * @param strValue not null string as two hexadecimal numbers of up to 8 digits each, separated by
+     *                 a slash. For example {@code 16/3002D50}, {@code 0/15D68C50}
+     * @return the LSN or {@link LogSequenceNumber#INVALID_LSN} if specified string does not have not valid form
+     */
+    public static LogSequenceNumber valueOf(String strValue) {
+        int slashIndex = strValue.lastIndexOf('/');
+
+        if (slashIndex <= 0) {
+            return INVALID_LSN;
+        }
+
+        String logicalXLogStr = strValue.substring(0, slashIndex);
+        int logicalXlog = (int) Long.parseLong(logicalXLogStr, 16);
+        String segmentStr = strValue.substring(slashIndex + 1);
+        int segment = (int) Long.parseLong(segmentStr, 16);
+
+        long value = ((long) logicalXlog) << 32 | segment;
+
+        return LogSequenceNumber.valueOf(value);
+    }
+
+    /**
+     * @return Long represent position in the write-ahead log stream
+     */
+    public long asLong() {
+        return this.value;
+    }
+
+    /**
+     * @return String represent position in the write-ahead log stream as two hexadecimal numbers of
+     * up to 8 digits each, separated by a slash. For example {@code 16/3002D50}, {@code 0/15D68C50}
+     */
+    public String asString() {
+        int logicalXlog = (int) (this.value >> 32);
+        int segment = (int) (this.value);
+        return String.format("%X/%X", logicalXlog, segment);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof LogSequenceNumber)) {
+            return false;
+        }
+        LogSequenceNumber that = (LogSequenceNumber) o;
+        return this.value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.value);
+    }
+
+    @Override
+    public String toString() {
+        return "LSN{" + asString() + '}';
+    }
+
+    @Override
+    public int compareTo(LogSequenceNumber o) {
+        if (this.value == o.value) {
+            return 0;
+        }
+        //Unsigned comparison
+        return this.value + Long.MIN_VALUE < o.value + Long.MIN_VALUE ? -1 : 1;
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/replication/ReplicationRequest.java
+++ b/src/main/java/io/r2dbc/postgresql/replication/ReplicationRequest.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+import io.r2dbc.postgresql.util.Assert;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+
+/**
+ * Value object representing a request to create a replication slot.
+ * <p>Use {@link #logical()}  to configure a logical replication stream and {@link #physical()} to configure a physical one.
+ * <p>
+ * TODO: Better name
+ */
+public abstract class ReplicationRequest {
+
+    final ReplicationType replicationType;
+
+    final String slotName;
+
+    final LogSequenceNumber startPosition;
+
+    final Duration statusInterval;
+
+    ReplicationRequest(ReplicationType replicationType, String slotName, LogSequenceNumber startPosition, Duration statusInterval) {
+        this.replicationType = Assert.requireNonNull(replicationType, "replicationType must not be null");
+        this.slotName = Assert.requireNotEmpty(slotName, "slotName must not be null");
+        this.startPosition = Assert.requireNonNull(startPosition, "startPosition must not be null");
+        this.statusInterval = Assert.requireNonNull(statusInterval, "statusInterval must not be null");
+    }
+
+    /**
+     * Creates a new builder to configure a logical {@link ReplicationRequest}.
+     *
+     * @return a new builder to configure a logical {@link ReplicationRequest}.
+     */
+    public static LogicalReplicationStep1 logical() {
+        return new DefaultLogicalReplicationRequestBuilder();
+    }
+
+    /**
+     * Creates a new builder to configure a physical {@link ReplicationRequest}.
+     *
+     * @return a new builder to configure a physical {@link ReplicationRequest}.
+     */
+    public static PhysicalReplicationStep1 physical() {
+        return new DefaultPhysicalReplicationRequestBuilder();
+    }
+
+    /**
+     * Creates a new builder to configure a logical {@link ReplicationRequest} from {@link ReplicationSlot}.
+     *
+     * @param replicationSlot the replication slot to initialize {@link LogicalReplicationRequestBuilder}.
+     * @return a new builder to configure a logical {@link ReplicationRequest} from {@link ReplicationSlot}.
+     */
+    public static LogicalReplicationRequestBuilder logical(ReplicationSlot replicationSlot) {
+        Assert.requireNonNull(replicationSlot, "replicationSlot must not be null");
+        return logical().slotName(replicationSlot.getSlotName()).startPosition(replicationSlot.getConsistentPoint());
+    }
+
+    /**
+     * Renders this request as SQL.
+     *
+     * @return this request as SQL.
+     */
+    public abstract String asSQL();
+
+    /**
+     * Returns the replication type of the slot, {@code PHYSICAL} or {@code LOGICAL}.
+     *
+     * @return {@link ReplicationType}, {@code PHYSICAL} or {@code LOGICAL}
+     */
+    public ReplicationType getReplicationType() {
+        return this.replicationType;
+    }
+
+    /**
+     * @return status update interval
+     */
+    public Duration getStatusInterval() {
+        return this.statusInterval;
+    }
+
+    static class LogicalReplicationRequest extends ReplicationRequest {
+
+        private final Map<String, Object> slotOptions;
+
+        LogicalReplicationRequest(String slotName, LogSequenceNumber startPosition, Duration statusInterval, Map<String, Object> slotOptions) {
+            super(ReplicationType.LOGICAL, slotName, startPosition, statusInterval);
+            this.slotOptions = slotOptions;
+        }
+
+        @Override
+        public String asSQL() {
+
+            String sql = String.format("START_REPLICATION SLOT %s LOGICAL %s", this.slotName, this.startPosition.asString());
+
+            if (this.slotOptions.isEmpty()) {
+                return sql;
+            }
+
+            StringJoiner joiner = new StringJoiner(", ", " (", ")");
+            for (String name : this.slotOptions.keySet()) {
+                joiner.add(String.format("\"%s\" '%s'", name, this.slotOptions.get(name)));
+            }
+
+            return sql + joiner;
+        }
+
+    }
+
+    static class PhysicalReplicationRequest extends ReplicationRequest {
+
+        public PhysicalReplicationRequest(String slotName, LogSequenceNumber startPosition, Duration statusInterval) {
+            super(ReplicationType.PHYSICAL, slotName, startPosition, statusInterval);
+        }
+
+        @Override
+        public String asSQL() {
+            return String.format("START_REPLICATION SLOT %s PHYSICAL %s", this.slotName, this.startPosition.asString());
+        }
+
+    }
+
+    final static class DefaultLogicalReplicationRequestBuilder implements LogicalReplicationRequestBuilder {
+
+        private String slotName;
+
+        private LogSequenceNumber startPosition;
+
+        private Duration statusInterval = Duration.ofSeconds(10);
+
+        private Map<String, Object> slotOptions = new LinkedHashMap<>();
+
+        @Override
+        public LogicalReplicationRequestBuilder slotName(String slotName) {
+            this.slotName = Assert.requireNotEmpty(slotName, "slotName must not be null and not empty");
+            return this;
+        }
+
+        @Override
+        public LogicalReplicationRequestBuilder startPosition(LogSequenceNumber lsn) {
+            this.startPosition = Assert.requireNonNull(lsn, "lsn must not be null");
+            return this;
+        }
+
+        @Override
+        public LogicalReplicationRequestBuilder statusInterval(Duration interval) {
+            this.statusInterval = Assert.requireNonNull(interval, "interval must not be null");
+            return this;
+        }
+
+        @Override
+        public LogicalReplicationRequestBuilder slotOption(String option, Object value) {
+            Assert.requireNotEmpty(option, "option must not be null and not empty");
+            Assert.requireNonNull(value, "value must not be null");
+            this.slotOptions.put(option, value);
+
+            return this;
+        }
+
+        @Override
+        public ReplicationRequest build() {
+            return new LogicalReplicationRequest(this.slotName, this.startPosition, this.statusInterval, this.slotOptions);
+        }
+
+    }
+
+    final static class DefaultPhysicalReplicationRequestBuilder implements PhysicalReplicationRequestBuilder {
+
+        private String slotName;
+
+        private LogSequenceNumber startPosition;
+
+        private Duration statusInterval = Duration.ofSeconds(10);
+
+        @Override
+        public PhysicalReplicationRequestBuilder slotName(String slotName) {
+            this.slotName = Assert.requireNotEmpty(slotName, "slotName must not be null and not empty");
+            return this;
+        }
+
+        @Override
+        public PhysicalReplicationRequestBuilder startPosition(LogSequenceNumber lsn) {
+            this.startPosition = Assert.requireNonNull(lsn, "lsn must not be null");
+            return this;
+        }
+
+        @Override
+        public PhysicalReplicationRequestBuilder statusInterval(Duration interval) {
+            this.statusInterval = Assert.requireNonNull(interval, "interval must not be null");
+            return this;
+        }
+
+        @Override
+        public ReplicationRequest build() {
+            return new PhysicalReplicationRequest(this.slotName, this.startPosition, this.statusInterval);
+        }
+
+    }
+
+    /**
+     * Fluent builder interface to configure the slot name for a logical replication slot.
+     */
+    public interface LogicalReplicationStep1 extends WithSlotName {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalReplicationStep2 slotName(String slotName);
+
+    }
+
+    public interface LogicalReplicationStep2 extends LogicalReplicationStep1, WithStartPosition {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalReplicationRequestBuilder startPosition(LogSequenceNumber lsn);
+
+    }
+
+    /**
+     * Fluent builder interface to configure a logical replication stream.
+     */
+    public interface LogicalReplicationRequestBuilder extends LogicalReplicationStep1, LogicalReplicationStep2, WithSlotName, WithStartPosition, WithStatusInterval, WithSlotOption {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalReplicationRequestBuilder slotName(String slotName);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalReplicationRequestBuilder startPosition(LogSequenceNumber lsn);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalReplicationRequestBuilder statusInterval(Duration interval);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalReplicationRequestBuilder slotOption(String option, Object value);
+
+        /**
+         * Returns the logical {@link ReplicationRequest}.
+         *
+         * @return the logical {@link ReplicationRequest}.
+         */
+        ReplicationRequest build();
+
+    }
+
+    /**
+     * Fluent builder interface to configure the slot name for a physical replication slot.
+     */
+    public interface PhysicalReplicationStep1 extends WithSlotName {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        PhysicalReplicationStep2 slotName(String slotName);
+
+    }
+
+    public interface PhysicalReplicationStep2 extends PhysicalReplicationStep1, WithStartPosition {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        PhysicalReplicationRequestBuilder startPosition(LogSequenceNumber lsn);
+
+    }
+
+    /**
+     * Fluent builder interface to configure a physical replication stream.
+     */
+    public interface PhysicalReplicationRequestBuilder extends PhysicalReplicationStep1, PhysicalReplicationStep2, WithSlotName, WithStartPosition, WithStatusInterval {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        PhysicalReplicationRequestBuilder slotName(String slotName);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        PhysicalReplicationRequestBuilder startPosition(LogSequenceNumber lsn);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        PhysicalReplicationRequestBuilder statusInterval(Duration interval);
+
+        /**
+         * Returns the physical {@link ReplicationRequest}.
+         *
+         * @return the physical {@link ReplicationRequest}.
+         */
+        ReplicationRequest build();
+
+    }
+
+    /**
+     * Fluent builder interface fragment to associate the builder with status interval updates.
+     */
+    public interface WithStatusInterval {
+
+        /**
+         * Specifies the number of time between status packets sent back to the server. This allows for easier monitoring of the progress from server. A value of zero disables the periodic status
+         * updates completely, although an update will still be sent when requested by the server, to avoid timeout disconnect. The default value is 10 seconds.
+         *
+         * @param interval positive time
+         * @return {@code this} builder.
+         * @throws IllegalArgumentException if {@code interval} is {@code null}
+         */
+        WithStatusInterval statusInterval(Duration interval);
+
+    }
+
+    /**
+     * Fluent builder interface fragment to associate the builder with slot options.
+     */
+    public interface WithSlotOption {
+
+        /**
+         * Configure slot option.
+         *
+         * @param option slot option name
+         * @param value  option value
+         * @return this instance as a fluent interface
+         * @throws IllegalArgumentException if {@code option} or {@code value} is {@code null} or {@code option} is empty
+         */
+        WithSlotName slotOption(String option, Object value);
+
+    }
+
+    /**
+     * Fluent builder interface fragment to associate the builder with the slot name.
+     */
+    public interface WithSlotName {
+
+        /**
+         * Replication slots provide an automated way to ensure that the master does not remove WAL segments until they have been received by all standbys, and that the master does not remove rows
+         * which could cause a recovery conflict even when the standby is disconnected.
+         *
+         * @param slotName not null replication slot already exists on server
+         * @return {@code this} builder
+         * @throws IllegalArgumentException if {@code slotName} is {@code null} or empty
+         */
+        WithSlotName slotName(String slotName);
+
+    }
+
+    public interface WithStartPosition {
+
+        /**
+         * Specify start position from which backend will start stream changes. If parameter will not specify, streaming starts from restart_lsn. For more details see pg_replication_slots description.
+         *
+         * @param lsn not null position from which need start replicate changes
+         * @return {@code this} builder
+         * @throws IllegalArgumentException if {@code slotName} is {@code null}
+         */
+        WithStartPosition startPosition(LogSequenceNumber lsn);
+
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/replication/ReplicationSlot.java
+++ b/src/main/java/io/r2dbc/postgresql/replication/ReplicationSlot.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+import reactor.util.annotation.Nullable;
+
+/**
+ * Information returned on replication slot creation.
+ *
+ * <p>Returned keys of CREATE_REPLICATION_SLOT:
+ * <ol>
+ * <li><b>slot_name</b> String {@code =>} the slot name
+ * <li><b>consistent_point</b> String {@code =>} LSN at which we became consistent
+ * <li><b>snapshot_name</b> String {@code =>} exported snapshot's name (may be {@code null})
+ * <li><b>output_plugin</b> String {@code =>} output plugin (may be {@code null})
+ * </ol>
+ */
+public final class ReplicationSlot {
+
+    private final String slotName;
+
+    private final ReplicationType replicationType;
+
+    private final LogSequenceNumber consistentPoint;
+
+    @Nullable
+    private final String snapshotName;
+
+    @Nullable
+    private final String outputPlugin;
+
+    public ReplicationSlot(String slotName, ReplicationType replicationType,
+                           LogSequenceNumber consistentPoint, @Nullable String snapshotName, @Nullable String outputPlugin) {
+        this.slotName = slotName;
+        this.replicationType = replicationType;
+        this.consistentPoint = consistentPoint;
+        this.snapshotName = snapshotName;
+        this.outputPlugin = outputPlugin;
+    }
+
+    /**
+     * Returns the replication slot name.
+     *
+     * @return the slot name
+     */
+    public String getSlotName() {
+        return this.slotName;
+    }
+
+    /**
+     * Replication type of the slot created, {@code PHYSICAL} or {@code LOGICAL}.
+     *
+     * @return {@link ReplicationType}, {@code PHYSICAL} or {@code LOGICAL}
+     */
+    public ReplicationType getReplicationType() {
+        return this.replicationType;
+    }
+
+    /**
+     * Returns the {@link LogSequenceNumber LSN} at which we became consistent.
+     *
+     * @return {@link LogSequenceNumber} at {@code consistent_point}
+     */
+    public LogSequenceNumber getConsistentPoint() {
+        return this.consistentPoint;
+    }
+
+    /**
+     * Returns the exported snapshot name at the point of replication slot creation.
+     *
+     * <p>As long as the exporting transaction remains open, other transactions can import its snapshot,
+     * and thereby be guaranteed that they see exactly the same view of the database that the first
+     * transaction sees.
+     *
+     * @return exported {@code snapshot_name}
+     */
+    @Nullable
+    public String getSnapshotName() {
+        return this.snapshotName;
+    }
+
+    /**
+     * Returns the output plugin used on slot creation.
+     *
+     * @return the output plugin used on slot creation
+     */
+    @Nullable
+    public String getOutputPlugin() {
+        return this.outputPlugin;
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/replication/ReplicationSlotRequest.java
+++ b/src/main/java/io/r2dbc/postgresql/replication/ReplicationSlotRequest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+import io.r2dbc.postgresql.util.Assert;
+
+/**
+ * Value object representing a request to create a replication slot.
+ * <p>Use {@link #logical()}  to configure a logical replication slot and {@link #physical()} to configure a physical one.
+ * <p>
+ * TODO: Better name
+ */
+public abstract class ReplicationSlotRequest {
+
+    private final ReplicationType replicationType;
+
+    private final String slotName;
+
+    private final boolean temporary;
+
+    ReplicationSlotRequest(ReplicationType replicationType, String slotName, boolean temporary) {
+        this.replicationType = Assert.requireNonNull(replicationType, "replicationType must not be null");
+        this.slotName = Assert.requireNotEmpty(slotName, "slotName must not be null");
+        this.temporary = temporary;
+    }
+
+    /**
+     * Creates a new builder to configure a logical {@link ReplicationSlotRequest}.
+     *
+     * @return a new builder to configure a logical {@link ReplicationSlotRequest}.
+     */
+    public static LogicalSlotRequestBuilderStep1 logical() {
+        return new DefaultLogicalSlotRequestBuilder();
+    }
+
+    /**
+     * Creates a new builder to configure a physical {@link ReplicationSlotRequest}.
+     *
+     * @return a new builder to configure a physical {@link ReplicationSlotRequest}.
+     */
+    public static PhysicalSlotRequestBuilderStep1 physical() {
+        return new DefaultPhysicalSlotRequestBuilder();
+    }
+
+    /**
+     * Renders this request as SQL.
+     *
+     * @return this request as SQL.
+     */
+    public abstract String asSQL();
+
+    /**
+     * Returns the replication type of the slot, {@code PHYSICAL} or {@code LOGICAL}.
+     *
+     * @return {@link ReplicationType}, {@code PHYSICAL} or {@code LOGICAL}
+     */
+    public ReplicationType getReplicationType() {
+        return this.replicationType;
+    }
+
+    /**
+     * Returns the replication slot name.
+     *
+     * @return the slot name
+     */
+    String getSlotName() {
+        return this.slotName;
+    }
+
+    /**
+     * Returns the slot is temporary.
+     *
+     * @return {@literal true} if the slot should be temporary.
+     */
+    boolean isTemporary() {
+        return this.temporary;
+    }
+
+    /**
+     * Slot creation request for logical replication.
+     */
+    static class LogicalReplicationSlotRequest extends ReplicationSlotRequest {
+
+        private final String outputPlugin;
+
+        public LogicalReplicationSlotRequest(String slotName, boolean temporaryOption, String outputPlugin) {
+            super(ReplicationType.LOGICAL, slotName, temporaryOption);
+            this.outputPlugin = outputPlugin;
+        }
+
+        @Override
+        public String asSQL() {
+            return String.format(
+                "CREATE_REPLICATION_SLOT %s %s LOGICAL %s",
+                getSlotName(),
+                isTemporary() ? "TEMPORARY" : "",
+                this.outputPlugin
+            );
+        }
+
+        @Override
+        public String toString() {
+            return "LogicalReplicationSlotRequest{" +
+                "slotName='" + getSlotName() + '\'' +
+                ", outputPlugin='" + this.outputPlugin + '\'' +
+                ", temporaryOption=" + isTemporary() +
+                '}';
+        }
+
+    }
+
+    /**
+     * Slot creation request for physical replication.
+     */
+    static class PhysicalReplicationSlotRequest extends ReplicationSlotRequest {
+
+        public PhysicalReplicationSlotRequest(String slotName, boolean temporaryOption) {
+            super(ReplicationType.PHYSICAL, slotName, temporaryOption);
+        }
+
+        @Override
+        public String asSQL() {
+            return String.format(
+                "CREATE_REPLICATION_SLOT %s %s PHYSICAL",
+                getSlotName(),
+                isTemporary() ? "TEMPORARY" : ""
+            );
+        }
+
+        @Override
+        public String toString() {
+            return "PhysicalReplicationSlotRequest{" +
+                "slotName='" + getSlotName() + '\'' +
+                ", temporaryOption=" + isTemporary() +
+                '}';
+        }
+
+    }
+
+    final static class DefaultLogicalSlotRequestBuilder implements LogicalSlotRequestBuilder {
+
+        private String slotName;
+
+        private String outputPlugin;
+
+        private boolean temporary;
+
+        @Override
+        public LogicalSlotRequestBuilder slotName(String slotName) {
+            this.slotName = Assert.requireNotEmpty(slotName, "slotName must not be null and not empty");
+            return this;
+        }
+
+        @Override
+        public LogicalSlotRequestBuilder outputPlugin(String outputPlugin) {
+            this.outputPlugin = Assert.requireNotEmpty(outputPlugin, "outputPlugin must not be null and not empty");
+            return this;
+        }
+
+        @Override
+        public LogicalSlotRequestBuilder temporary() {
+            this.temporary = true;
+            return this;
+        }
+
+        @Override
+        public ReplicationSlotRequest build() {
+            return new LogicalReplicationSlotRequest(this.slotName, this.temporary, this.outputPlugin);
+        }
+
+    }
+
+    final static class DefaultPhysicalSlotRequestBuilder implements PhysicalSlotRequestBuilder {
+
+        private String slotName;
+
+        private boolean temporary;
+
+        @Override
+        public DefaultPhysicalSlotRequestBuilder slotName(String slotName) {
+            this.slotName = Assert.requireNotEmpty(slotName, "slotName must not be null and not empty");
+            return this;
+        }
+
+        @Override
+        public DefaultPhysicalSlotRequestBuilder temporary() {
+            this.temporary = true;
+            return this;
+        }
+
+        @Override
+        public ReplicationSlotRequest build() {
+            return new PhysicalReplicationSlotRequest(this.slotName, this.temporary);
+        }
+
+    }
+
+    /**
+     * Fluent builder interface to configure the slot name for a logical replication slot.
+     */
+    public interface LogicalSlotRequestBuilderStep1 extends WithSlotName {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalSlotRequestBuilderStep2 slotName(String slotName);
+
+    }
+
+    public interface LogicalSlotRequestBuilderStep2 extends WithOutputPlugin, WithSlotName {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalSlotRequestBuilder outputPlugin(String outputPlugin);
+
+    }
+
+    /**
+     * Fluent builder interface to configure a logical replication slot.
+     */
+    public interface LogicalSlotRequestBuilder extends LogicalSlotRequestBuilderStep1, LogicalSlotRequestBuilderStep2, WithTemporary {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalSlotRequestBuilder slotName(String slotName);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        LogicalSlotRequestBuilder temporary();
+
+        /**
+         * Builds the logical {@link ReplicationSlotRequest}.
+         *
+         * @return the logical {@link ReplicationSlotRequest}.
+         */
+        ReplicationSlotRequest build();
+
+    }
+
+    /**
+     * Fluent builder interface to configure the slot name for a physical replication slot.
+     */
+    public interface PhysicalSlotRequestBuilderStep1 extends WithSlotName {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        PhysicalSlotRequestBuilder slotName(String slotName);
+
+    }
+
+    /**
+     * Fluent builder interface to configure a physical replication slot.
+     */
+    public interface PhysicalSlotRequestBuilder extends PhysicalSlotRequestBuilderStep1, WithTemporary {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        PhysicalSlotRequestBuilder slotName(String slotName);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        PhysicalSlotRequestBuilder temporary();
+
+        /**
+         * Builds the physical {@link ReplicationSlotRequest}.
+         *
+         * @return the physical {@link ReplicationSlotRequest}.
+         */
+        ReplicationSlotRequest build();
+
+    }
+
+    /**
+     * Fluent builder interface fragment to associate the builder with the temporary option.
+     */
+    public interface WithTemporary {
+
+        /**
+         * <p>Temporary slots are not saved to disk and are automatically dropped on error or when
+         * the session has finished.
+         *
+         * <p>This feature is only supported by PostgreSQL versions &gt;= 10.</p>
+         *
+         * @return {@code this} builder
+         */
+        WithTemporary temporary();
+
+    }
+
+    /**
+     * Fluent builder interface fragment to associate the builder with a slot name.
+     */
+    public interface WithSlotName {
+
+        /**
+         * Replication slots provide an automated way to ensure that the master does not remove WAL segments until they have been received by all standbys, and that the master does not remove rows
+         * which could cause a recovery conflict even when the standby is disconnected.
+         *
+         * @param slotName replication slot name for create, must not be {@code null} or empty
+         * @return {@code this} builder
+         * @throws IllegalArgumentException if {@code slotName} is {@code null} or empty
+         */
+        WithSlotName slotName(String slotName);
+
+    }
+
+    /**
+     * Fluent builder interface fragment to associate the builder with an output plugin.
+     */
+    public interface WithOutputPlugin {
+
+        /**
+         * <p>Output plugin that should be use for decode physical represent WAL to some logical form. Output plugin should be installed on server(exists in shared_preload_libraries).
+         *
+         * <p>Package postgresql-contrib provides sample output plugin <b>test_decoding</b> that can be use for test logical replication api.
+         *
+         * @param outputPlugin name of the output plugin used for logical decoding, must not be {@code null} or empty
+         * @return {@code this} builder
+         * @throws IllegalArgumentException if {@code outputPlugin} is {@code null} or empty
+         */
+        WithOutputPlugin outputPlugin(String outputPlugin);
+
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/replication/ReplicationStream.java
+++ b/src/main/java/io/r2dbc/postgresql/replication/ReplicationStream.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.postgresql.api.PostgresqlReplicationConnection;
+import io.r2dbc.spi.Closeable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+/**
+ * Postgresql replication stream. Once established, the stream occupies the {@link PostgresqlReplicationConnection} until this stream is {@link #close() closed}. This stream can be consumed by
+ * applying a {@link Function mapping function} using {@link #map(Function)}.
+ */
+public interface ReplicationStream extends Closeable {
+
+    /**
+     * Stop replication changes from server and free resources. After that connection can be reused. Also after closing the current stream this object cannot be used anymore. Subscribers will see a
+     * completion signal if they are still subscribed.
+     *
+     * @return a {@link Mono} that termination is complete
+     */
+    @Override
+    Mono<Void> close();
+
+    /**
+     * @return {@code true} if replication stream was already closed, otherwise return {@code false}
+     */
+    boolean isClosed();
+
+    /**
+     * Returns a mapping of the replication stream which is an unbounded stream.
+     * <p>The {@link ByteBuf data buffer} is released after applying the {@link Function mapping function}.
+     * <p>Unsubscribing from the stream will cancel consumption leaving protocol frames on the transport buffer. {@link #close() Close the} {@code ReplicationStream} object to terminate the
+     *
+     * @param mappingFunction the {@link Function} that maps a {@link ByteBuf} to a value.
+     * @param <T>             the type of the mapped value
+     * @return a mapping of the {@link ByteBuf data buffers} that are the results of the replication stream
+     * @throws IllegalArgumentException if {@code mappingFunction} is {@code null}
+     */
+    <T> Flux<T> map(Function<ByteBuf, ? extends T> mappingFunction);
+
+    /**
+     * Returns the last received LSN position.
+     *
+     * @return LSN position that was received with the last read via {@link #map(Function)}.
+     */
+    LogSequenceNumber getLastReceiveLSN();
+
+    /**
+     * Returns the last flushed lsn send in update message to backend.
+     *
+     * @return location of the last WAL flushed to disk in the standby
+     */
+    LogSequenceNumber getLastFlushedLSN();
+
+    /**
+     * Returns the last applied lsn send in update message to backed.
+     *
+     * @return location of the last WAL applied in the standby.
+     */
+    LogSequenceNumber getLastAppliedLSN();
+
+    /**
+     * Sets the flushed LSN. The parameter will be send to backend on next update status iteration. Flushed
+     * LSN position help backend define which wal can be recycle.
+     *
+     * @param flushed not null location of the last WAL flushed to disk in the standby.
+     */
+    void setFlushedLSN(LogSequenceNumber flushed);
+
+    /**
+     * Parameter used only physical replication and define which lsn already was apply on standby.
+     * Feedback will send to backend on next update status iteration.
+     *
+     * @param applied not null location of the last WAL applied in the standby.
+     */
+    void setAppliedLSN(LogSequenceNumber applied);
+
+}

--- a/src/main/java/io/r2dbc/postgresql/replication/ReplicationType.java
+++ b/src/main/java/io/r2dbc/postgresql/replication/ReplicationType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+/**
+ * Replication type.
+ */
+public enum ReplicationType {
+    LOGICAL,
+    PHYSICAL
+}

--- a/src/main/java/io/r2dbc/postgresql/replication/package-info.java
+++ b/src/main/java/io/r2dbc/postgresql/replication/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for logical and physical replication streams.
+ */
+
+@NonNullApi
+package io.r2dbc.postgresql.replication;
+
+import reactor.util.annotation.NonNullApi;

--- a/src/main/java/io/r2dbc/postgresql/util/Assert.java
+++ b/src/main/java/io/r2dbc/postgresql/util/Assert.java
@@ -75,6 +75,22 @@ public final class Assert {
     }
 
     /**
+     * Checks that a specified {@link String} is not {@code null} and not {@link String#isEmpty() empty} and throws a customized {@link IllegalArgumentException} if it is.
+     *
+     * @param t       the  {@link String} reference to check for nullity and emptiness
+     * @param message the detail message to be used in the event that an {@link IllegalArgumentException} is thrown
+     * @return {@code t} if not {@code null} or {@link String#isEmpty() empty}
+     * @throws IllegalArgumentException if {@code t} is {code null}
+     */
+    public static String requireNotEmpty(@Nullable String t, String message) {
+        if (t == null || t.isEmpty()) {
+            throw new IllegalArgumentException(message);
+        }
+
+        return t;
+    }
+
+    /**
      * Checks that the specified value is of a specific type.
      *
      * @param value   the value to check

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlResultTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlResultTest.java
@@ -23,7 +23,6 @@ import io.r2dbc.postgresql.message.backend.EmptyQueryResponse;
 import io.r2dbc.postgresql.message.backend.RowDescription;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.Collections;
@@ -84,17 +83,23 @@ final class PostgresqlResultTest {
     }
 
     @Test
-    void toResultRowDescription() {
+    void toResultRowDescriptionRowsUpdated() {
+        PostgresqlResult result = PostgresqlResult.toResult(MockCodecs.empty(), Flux.just(new RowDescription(Collections.emptyList()), new DataRow(), new CommandComplete
+            ("test", null, null)));
+
+        result.getRowsUpdated()
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    @Test
+    void toResultRowDescriptionMap() {
         PostgresqlResult result = PostgresqlResult.toResult(MockCodecs.empty(), Flux.just(new RowDescription(Collections.emptyList()), new DataRow(), new CommandComplete
             ("test", null, null)));
 
         result.map((row, rowMetadata) -> row)
             .as(StepVerifier::create)
             .expectNextCount(1)
-            .verifyComplete();
-
-        result.getRowsUpdated()
-            .as(StepVerifier::create)
             .verifyComplete();
     }
 

--- a/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientTest.java
+++ b/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientTest.java
@@ -751,9 +751,6 @@ final class ReactorNettyClientTest {
     private Flux<BackendMessage> datarowCleanup(Flux<BackendMessage> in) {
         return Flux.create(sink -> Flux.from(in).subscribe(message -> {
             sink.next(message);
-            if (message instanceof DataRow) {
-                ((DataRow) message).release();
-            }
             ReferenceCountUtil.release(message);
         }, sink::error, sink::complete));
     }

--- a/src/test/java/io/r2dbc/postgresql/message/frontend/CopyDataTest.java
+++ b/src/test/java/io/r2dbc/postgresql/message/frontend/CopyDataTest.java
@@ -18,9 +18,8 @@ package io.r2dbc.postgresql.message.frontend;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
-
 import static io.r2dbc.postgresql.message.frontend.FrontendMessageAssert.assertThat;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 final class CopyDataTest {
@@ -33,7 +32,8 @@ final class CopyDataTest {
 
     @Test
     void encode() {
-        assertThat(new CopyData(ByteBuffer.allocate(4).putInt(100))).encoded()
+        CopyData data = new CopyData(TEST.buffer(4).writeInt(100));
+        assertThat(data).encoded()
             .isDeferred()
             .isEncodedAs(buffer -> buffer
                 .writeByte('d')

--- a/src/test/java/io/r2dbc/postgresql/replication/LogicalDecodeIntegrationTest.java
+++ b/src/test/java/io/r2dbc/postgresql/replication/LogicalDecodeIntegrationTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import io.r2dbc.postgresql.api.PostgresqlConnection;
+import io.r2dbc.postgresql.api.PostgresqlReplicationConnection;
+import io.r2dbc.postgresql.api.PostgresqlResult;
+import io.r2dbc.postgresql.util.PostgresqlServerExtension;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class LogicalDecodeIntegrationTest {
+
+    @RegisterExtension
+    static final PostgresqlServerExtension SERVER = new PostgresqlServerExtension();
+
+    private final PostgresqlConnectionFactory connectionFactory = new PostgresqlConnectionFactory(PostgresqlConnectionConfiguration.builder()
+        .database(SERVER.getDatabase())
+        .host(SERVER.getHost())
+        .port(SERVER.getPort())
+        .password(SERVER.getPassword())
+        .username(SERVER.getUsername())
+        .forceBinary(true)
+        .build());
+
+    @Test
+    void shouldCreateReplicationSlot() {
+
+        PostgresqlReplicationConnection replicationConnection = this.connectionFactory.replication().block();
+
+        ReplicationSlotRequest request = ReplicationSlotRequest.logical().slotName("rs" + UUID.randomUUID().toString().replace("-", "")).outputPlugin("test_decoding").temporary().build();
+        replicationConnection.createSlot(request).as(StepVerifier::create).consumeNextWith(actual -> {
+
+            assertThat(actual.getSlotName()).isEqualTo(request.getSlotName());
+            assertThat(actual.getOutputPlugin()).isEqualTo("test_decoding");
+            assertThat(actual.getConsistentPoint()).isNotNull();
+            assertThat(actual.getSnapshotName()).isNotNull();
+
+        }).verifyComplete();
+    }
+
+    @Test
+    void shouldStartReplication() {
+
+        PostgresqlReplicationConnection replicationConnection = this.connectionFactory.replication().block();
+        ReplicationSlotRequest request = createSlot(replicationConnection);
+
+        ReplicationRequest replicationRequest = ReplicationRequest.logical().slotName(request.getSlotName()).startPosition(LogSequenceNumber.valueOf(0)).slotOption("skip-empty-xacts", true)
+            .slotOption("include-xids", false).build();
+
+        ReplicationStream replicationStream = replicationConnection.startReplication(replicationRequest).block(Duration.ofSeconds(10));
+
+        assertThat(replicationStream.isClosed()).isFalse();
+        assertThat(replicationStream.getLastReceiveLSN()).isNotNull();
+        assertThat(replicationStream.getLastAppliedLSN()).isNotNull();
+        assertThat(replicationStream.getLastFlushedLSN()).isNotNull();
+
+        replicationStream.close().as(StepVerifier::create).verifyComplete();
+
+        assertThat(replicationStream.isClosed()).isTrue();
+    }
+
+    @Test
+    void shouldReceiveReplication() {
+
+        PostgresqlReplicationConnection replicationConnection = this.connectionFactory.replication().block();
+        PostgresqlConnection connection = this.connectionFactory.create().block();
+
+        prepare(connection);
+
+        ReplicationSlotRequest request = createSlot(replicationConnection);
+
+        ReplicationRequest replicationRequest = ReplicationRequest.logical().slotName(request.getSlotName()).startPosition(LogSequenceNumber.valueOf(0)).slotOption("skip-empty-xacts", true)
+            .slotOption("include-xids", false).build();
+
+        ReplicationStream replicationStream = replicationConnection.startReplication(replicationRequest).block(Duration.ofSeconds(10));
+
+        connection.createStatement("INSERT INTO test VALUES('Hello World')").execute().flatMap(PostgresqlResult::getRowsUpdated).as(StepVerifier::create).expectNext(1).verifyComplete();
+
+        replicationStream.map(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8))
+            .as(StepVerifier::create)
+            .expectNext("BEGIN")
+            .expectNext("table public.test: INSERT: first_name[character varying]:'Hello World'")
+            .expectNext("COMMIT")
+            .then(() -> replicationStream.close().subscribe())
+            .verifyComplete();
+
+        assertThat(replicationStream.isClosed()).isTrue();
+        replicationStream.close().as(StepVerifier::create).verifyComplete();
+        assertThat(replicationStream.isClosed()).isTrue();
+    }
+
+    @Test
+    void replicationShouldFailWithWrongSlotType() {
+
+        PostgresqlReplicationConnection replicationConnection = this.connectionFactory.replication().block();
+        PostgresqlConnection connection = this.connectionFactory.create().block();
+
+        prepare(connection);
+
+        ReplicationSlotRequest request = createSlot(replicationConnection);
+
+        ReplicationRequest replicationRequest = ReplicationRequest.physical().slotName(request.getSlotName()).startPosition(LogSequenceNumber.valueOf(0)).build();
+
+        replicationConnection
+            .startReplication(replicationRequest)
+            .as(StepVerifier::create)
+            .verifyError(R2dbcNonTransientResourceException.class);
+    }
+
+    private void prepare(PostgresqlConnection connection) {
+        connection.createStatement("DROP TABLE IF EXISTS test").execute().flatMap(PostgresqlResult::getRowsUpdated).as(StepVerifier::create).verifyComplete();
+
+        connection.createStatement("CREATE TABLE test (first_name varchar(255))").execute().flatMap(PostgresqlResult::getRowsUpdated).as(StepVerifier::create).verifyComplete();
+    }
+
+    private ReplicationSlotRequest createSlot(PostgresqlReplicationConnection replicationConnection) {
+        ReplicationSlotRequest request = ReplicationSlotRequest.logical().slotName("RS" + UUID.randomUUID().toString().replace("-", "")).outputPlugin("test_decoding").temporary().build();
+        replicationConnection.createSlot(request).as(StepVerifier::create).expectNextCount(1).verifyComplete();
+        return request;
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/replication/ReplicationRequestTest.java
+++ b/src/test/java/io/r2dbc/postgresql/replication/ReplicationRequestTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+final class ReplicationRequestTest {
+
+    @Test
+    void rejectsInvalidSlot() {
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationRequest.logical().slotName(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationRequest.logical().slotName(""));
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationRequest.physical().slotName(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationRequest.physical().slotName(""));
+    }
+
+    @Test
+    void rejectsInvalidOutputLsn() {
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationRequest.logical().slotName("foo").startPosition(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationRequest.physical().slotName("foo").startPosition(null));
+    }
+
+    @Test
+    void buildsLogicalRequest() {
+        ReplicationRequest request = ReplicationRequest.logical().slotName("slot")
+            .startPosition(LogSequenceNumber.valueOf(0))
+            .statusInterval(Duration.ofSeconds(11))
+            .slotOption("skip-empty-xacts", true)
+            .slotOption("include-xids", false).build();
+        assertThat(request.getReplicationType()).isEqualTo(ReplicationType.LOGICAL);
+        assertThat(request.getStatusInterval()).isEqualTo(Duration.ofSeconds(11));
+        assertThat(request.asSQL()).isEqualTo("START_REPLICATION SLOT slot LOGICAL 0/0 (\"skip-empty-xacts\" 'true', \"include-xids\" 'false')");
+    }
+
+    @Test
+    void buildsPhysicalRequest() {
+        ReplicationRequest request = ReplicationRequest.physical().slotName("slot")
+            .startPosition(LogSequenceNumber.valueOf(0))
+            .statusInterval(Duration.ofSeconds(11)).build();
+        assertThat(request.getReplicationType()).isEqualTo(ReplicationType.PHYSICAL);
+        assertThat(request.getStatusInterval()).isEqualTo(Duration.ofSeconds(11));
+        assertThat(request.asSQL()).isEqualTo("START_REPLICATION SLOT slot PHYSICAL 0/0");
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/replication/ReplicationSlotRequestTest.java
+++ b/src/test/java/io/r2dbc/postgresql/replication/ReplicationSlotRequestTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.replication;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+final class ReplicationSlotRequestTest {
+
+    @Test
+    void rejectsInvalidSlot() {
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationSlotRequest.logical().slotName(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationSlotRequest.logical().slotName(""));
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationSlotRequest.physical().slotName(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationSlotRequest.physical().slotName(""));
+    }
+
+    @Test
+    void rejectsInvalidOutputPlugin() {
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationSlotRequest.logical().slotName("foo").outputPlugin(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> ReplicationSlotRequest.logical().slotName("foo").outputPlugin(""));
+    }
+
+    @Test
+    void buildsLogicalRequest() {
+        ReplicationSlotRequest request = ReplicationSlotRequest.logical().slotName("slot").outputPlugin("output").temporary().build();
+        assertThat(request.getReplicationType()).isEqualTo(ReplicationType.LOGICAL);
+        assertThat(request.getSlotName()).isEqualTo("slot");
+        assertThat(request.isTemporary()).isTrue();
+        assertThat(request.asSQL()).isEqualTo("CREATE_REPLICATION_SLOT slot TEMPORARY LOGICAL output");
+    }
+
+    @Test
+    void buildsPhysicalRequest() {
+        ReplicationSlotRequest request = ReplicationSlotRequest.physical().slotName("slot").temporary().build();
+        assertThat(request.getReplicationType()).isEqualTo(ReplicationType.PHYSICAL);
+        assertThat(request.getSlotName()).isEqualTo("slot");
+        assertThat(request.isTemporary()).isTrue();
+        assertThat(request.asSQL()).isEqualTo("CREATE_REPLICATION_SLOT slot TEMPORARY PHYSICAL");
+    }
+
+}

--- a/src/test/resources/setup.sh
+++ b/src/test/resources/setup.sh
@@ -14,6 +14,9 @@ chown postgres:postgres /var/runtime/*
 ls -l /var/runtime
 
 ./docker-entrypoint.sh postgres \
+  -c 'wal_level=logical' \
+  -c 'wal_keep_segments=4' \
+  -c 'max_replication_slots=4' \
   -c 'ssl=on' \
   -c 'ssl_key_file=/var/runtime/server.key' \
   -c 'ssl_cert_file=/var/runtime/server.crt' \


### PR DESCRIPTION
We now support consumption of replication streams through logical and physical decoding. The API exposes functionality to create replication slots and to consume a replication stream.

```java
ReplicationSlotRequest request = ReplicationSlotRequest.logical()
    .slotName("my_slot")
    .outputPlugin("test_decoding")
    .temporary()
    .build();
Mono<ReplicationSlot> replicationSlot = replicationConnection.createSlot(request);

ReplicationRequest replicationRequest = ReplicationRequest.logical()
    .slotName(request.getSlotName())
    .startPosition(LogSequenceNumber.valueOf(0))
    .slotOption("skip-empty-xacts", true)
    .slotOption("include-xids", false)
    .build();
Mono<ReplicationStream> replicationStream = replicationConnection.startReplication(replicationRequest);

// Later

Flux<…> replicationMessages = replicationStream.map(byteBuf -> …);
Mono<Void> close = replicationStream.close();
```

TODO:

* [x] Request/value object naming
* [x] Documentation (readme)