### PR TITLE
Add an auth-config for local connections in testing

### DIFF
--- a/src/test/resources/pg_hba.conf
+++ b/src/test/resources/pg_hba.conf
@@ -1,4 +1,5 @@
-hostnossl         all       test    all     md5
+hostnossl         all       test                    all     md5
 hostnossl         all       test-scram              all     scram-sha-256
-hostssl           all       test-ssl    all     password
+hostssl           all       test-ssl                all     password
 hostssl           all       test-ssl-with-cert      all     cert
+local             all       all                             md5


### PR DESCRIPTION
When the test suite is run with the testcontainers backend, the
integration tests were failing with newer versions of the postgres
docker image. The failures were caused by the docker-container not
properly starting which itself was caused by a missing entry in the
`pg_hba.conf` for local connections.

This commit adds the missing configuration for local connections.