### PR TITLE
Fix instant handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ This reference table shows the type mapping between [PostgreSQL][p] and Java dat
 | [`text`][psql-text-ref]                         | [**`String`**][java-string-ref], `Clob`|
 | [`time [without time zone]`][psql-time-ref]     | [`LocalTime`][java-lt-ref]|
 | [`time [with time zone]`][psql-time-ref]        | Not yet supported.|
-| [`timestamp [without time zone]`][psql-time-ref]|[**`LocalDateTime`**][java-ldt-ref], [`LocalTime`][java-lt-ref], [`LocalDate`][java-ld-ref]|
-| [`timestamp [with time zone]`][psql-time-ref]   | [**`OffsetDatetime`**][java-odt-ref], [`ZonedDateTime`][java-zdt-ref]|
+| [`timestamp [without time zone]`][psql-time-ref]|[**`LocalDateTime`**][java-ldt-ref], [`LocalTime`][java-lt-ref], [`LocalDate`][java-ld-ref], [`java.util.Date`][java-legacy-date-ref]|
+| [`timestamp [with time zone]`][psql-time-ref]   | [**`OffsetDatetime`**][java-odt-ref], [`ZonedDateTime`][java-zdt-ref], [`Instant`][java-instant-ref]|
 | [`tsquery`][psql-tsquery-ref]                   | Not yet supported.|
 | [`tsvector`][psql-tsvector-ref]                 | Not yet supported.|
 | [`txid_snapshot`][psql-txid_snapshot-ref]       | Not yet supported.|
@@ -349,6 +349,7 @@ Support for the following single-dimensional arrays (read and write):
 [java-ldt-ref]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalDateTime.html
 [java-ld-ref]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html
 [java-lt-ref]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalTime.html
+[java-legacy-date-ref]: https://docs.oracle.com/javase/8/docs/api/java/util/Date.html
 [java-odt-ref]: https://docs.oracle.com/javase/8/docs/api/java/time/OffsetDateTime.html
 [java-primitive-ref]: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
 [java-short-ref]: https://docs.oracle.com/javase/8/docs/api/java/lang/Short.html

--- a/src/main/java/io/r2dbc/postgresql/codec/DateCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/DateCodec.java
@@ -24,18 +24,19 @@ import io.r2dbc.postgresql.type.PostgresqlObjectId;
 import io.r2dbc.postgresql.util.Assert;
 import reactor.util.annotation.Nullable;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 final class DateCodec extends AbstractCodec<Date> {
 
-    private final InstantCodec delegate;
+    private final LocalDateTimeCodec delegate;
 
     DateCodec(ByteBufAllocator byteBufAllocator) {
         super(Date.class);
 
         Assert.requireNonNull(byteBufAllocator, "byteBufAllocator must not be null");
-        this.delegate = new InstantCodec(byteBufAllocator);
+        this.delegate = new LocalDateTimeCodec(byteBufAllocator);
     }
 
     @Override
@@ -55,14 +56,15 @@ final class DateCodec extends AbstractCodec<Date> {
     Date doDecode(ByteBuf buffer, PostgresqlObjectId dataType, @Nullable Format format, @Nullable Class<? extends Date> type) {
         Assert.requireNonNull(buffer, "byteBuf must not be null");
 
-        return Date.from(this.delegate.doDecode(buffer, dataType, format, Instant.class));
+        LocalDateTime intermediary = this.delegate.doDecode(buffer, dataType, format, LocalDateTime.class);
+        return Date.from(intermediary.atZone(ZoneId.systemDefault()).toInstant());
     }
 
     @Override
     Parameter doEncode(Date value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        return this.delegate.doEncode(value.toInstant());
+        return this.delegate.doEncode(value.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
     }
 
 }

--- a/src/main/java/io/r2dbc/postgresql/codec/InstantCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/InstantCodec.java
@@ -25,14 +25,10 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.time.*;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMP;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMPTZ;
 
 final class InstantCodec extends AbstractTemporalCodec<Instant> {
 
@@ -45,7 +41,7 @@ final class InstantCodec extends AbstractTemporalCodec<Instant> {
 
     @Override
     public Parameter encodeNull() {
-        return createNull(TIMESTAMP, FORMAT_TEXT);
+        return createNull(TIMESTAMPTZ, FORMAT_TEXT);
     }
 
     @Override
@@ -70,7 +66,7 @@ final class InstantCodec extends AbstractTemporalCodec<Instant> {
     Parameter doEncode(Instant value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        return create(TIMESTAMP, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
+        return create(TIMESTAMPTZ, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value.toString()));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/codec/LocalDateTimeCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/LocalDateTimeCodec.java
@@ -25,9 +25,7 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.*;
 
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.TIMESTAMP;
@@ -51,6 +49,10 @@ final class LocalDateTimeCodec extends AbstractTemporalCodec<LocalDateTime> {
         Assert.requireNonNull(buffer, "byteBuf must not be null");
 
         return decodeTemporal(buffer, dataType, format, LocalDateTime.class, temporal -> {
+            if (temporal instanceof LocalDate) {
+                return ((LocalDate) temporal).atStartOfDay(ZoneId.systemDefault()).toLocalDateTime();
+            }
+
             return Instant.from(temporal).atOffset(ZoneOffset.UTC).toLocalDateTime();
         });
     }

--- a/src/test/java/io/r2dbc/postgresql/AbstractCodecIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/AbstractCodecIntegrationTests.java
@@ -180,7 +180,7 @@ abstract class AbstractCodecIntegrationTests extends AbstractIntegrationTests {
 
     @Test
     void instant() {
-        testCodec(Instant.class, Instant.now(), "TIMESTAMP");
+        testCodec(Instant.class, Instant.now(), "TIMESTAMPTZ");
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/DateCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/DateCodecTest.java
@@ -49,9 +49,10 @@ final class DateCodecTest {
 
     @Test
     void decode() {
-        Date date = Date.from(Instant.parse("2018-11-04T15:37:31.177Z"));
+        Instant testInstant = LocalDateTime.parse("2010-02-01T10:08:04.412").atZone(ZoneId.systemDefault()).toInstant();
+        Date date = Date.from(testInstant);
 
-        assertThat(new DateCodec(TEST).decode(encode(TEST, "2018-11-04 15:37:31.177"), dataType, FORMAT_TEXT, Date.class))
+        assertThat(new DateCodec(TEST).decode(encode(TEST, "2010-02-01 10:08:04.412"), dataType, FORMAT_TEXT, Date.class))
             .isEqualTo(date);
     }
 
@@ -91,12 +92,13 @@ final class DateCodecTest {
 
     @Test
     void doEncode() {
-        Date date = new Date();
+        Instant testInstant = LocalDateTime.parse("2010-02-01T10:08:04.412").atZone(ZoneId.systemDefault()).toInstant();
+        Date date = Date.from(testInstant);
 
         assertThat(new DateCodec(TEST).doEncode(date))
             .hasFormat(FORMAT_TEXT)
             .hasType(TIMESTAMP.getObjectId())
-            .hasValue(encode(TEST, date.toInstant().toString()));
+            .hasValue(encode(TEST, "2010-02-01T10:08:04.412"));
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/codec/InstantCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/InstantCodecTest.java
@@ -75,6 +75,8 @@ final class InstantCodecTest {
         assertThat(codec.doCanDecode(TIMESTAMP, FORMAT_BINARY)).isTrue();
         assertThat(codec.doCanDecode(MONEY, FORMAT_TEXT)).isFalse();
         assertThat(codec.doCanDecode(TIMESTAMP, FORMAT_TEXT)).isTrue();
+        assertThat(codec.doCanDecode(TIMESTAMPTZ, FORMAT_TEXT)).isTrue();
+        assertThat(codec.doCanDecode(TIMESTAMPTZ, FORMAT_BINARY)).isTrue();
     }
 
     @Test
@@ -95,7 +97,7 @@ final class InstantCodecTest {
 
         assertThat(new InstantCodec(TEST).doEncode(instant))
             .hasFormat(FORMAT_TEXT)
-            .hasType(TIMESTAMP.getObjectId())
+            .hasType(TIMESTAMPTZ.getObjectId())
             .hasValue(encode(TEST, instant.toString()));
     }
 
@@ -108,7 +110,7 @@ final class InstantCodecTest {
     @Test
     void encodeNull() {
         assertThat(new InstantCodec(TEST).encodeNull())
-            .isEqualTo(new Parameter(FORMAT_TEXT, TIMESTAMP.getObjectId(), NULL_VALUE));
+            .isEqualTo(new Parameter(FORMAT_TEXT, TIMESTAMPTZ.getObjectId(), NULL_VALUE));
     }
 
 }


### PR DESCRIPTION
Instants were (IMO) incorrectly mapped to `TIMESTAMP` on the wire. The [official postgres java docs](https://jdbc.postgresql.org/documentation/head/8-date-time.html) say so as well.

This PR includes two commits/changes:

a) Make `InstantCodec` use `TIMESTAMPTZ` - this is straightforward, tests have been updated accordingly

b) Make `DateCodec` not use `InstantCodec` anymore and use `LocalDateTime` instead. This is a bit more involved as we have to make use of LocalDateTime handles dates without time properly and we need to do some date-object juggling in general.

I guess this "breaks backwards compatibility" in a way, but as this can be considered a bug (we ran into this by accident as our test-suite just didn't want to turn green), it should still be fixed in my opinion.

If this passes the review, we could also add `Instant` to the supported types on the `README`.

I will also gladly sign the Contributing Agreement if this is required for this MR.
