### PR TITLE
Add OID to the NumericAbstractCodec SUPPORTED_TYPES

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/codec/AbstractNumericCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/AbstractNumericCodec.java
@@ -35,6 +35,7 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT2;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT8;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.NUMERIC;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.OID;;
 
 /**
  * Codec to decode all known numeric types.
@@ -43,7 +44,7 @@ import static io.r2dbc.postgresql.type.PostgresqlObjectId.NUMERIC;
  */
 abstract class AbstractNumericCodec<T extends Number> extends AbstractCodec<T> {
 
-    private static final Set<PostgresqlObjectId> SUPPORTED_TYPES = EnumSet.of(INT2, INT4, INT8, FLOAT4, FLOAT8, NUMERIC);
+    private static final Set<PostgresqlObjectId> SUPPORTED_TYPES = EnumSet.of(INT2, INT4, INT8, FLOAT4, FLOAT8, NUMERIC, OID);
 
     /**
      * Creates a new {@link AbstractCodec}.
@@ -133,9 +134,14 @@ abstract class AbstractNumericCodec<T extends Number> extends AbstractCodec<T> {
                     return buffer.readDouble();
                 }
                 return Double.parseDouble(ByteBufUtils.decode(buffer));
+            case OID:
+                if (FORMAT_BINARY == format) {
+                    return buffer.readInt();
+                }
+                return Integer.parseInt(ByteBufUtils.decode(buffer));
+            default:
+                throw new UnsupportedOperationException(String.format("Cannot decode value for type %s, format %s", dataType, format));
         }
-
-        throw new UnsupportedOperationException(String.format("Cannot decode value for type %s, format %s", dataType, format));
     }
 
     /**

--- a/src/test/java/io/r2dbc/postgresql/AbstractCodecIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/AbstractCodecIntegrationTests.java
@@ -193,6 +193,7 @@ abstract class AbstractCodecIntegrationTests extends AbstractIntegrationTests {
         testCodec(Integer.class, 100, "INT2");
         testCodec(Integer.class, 100, "INT4");
         testCodec(Integer.class, 100, "INT8");
+        testCodec(Integer.class, 100, "OID");
         testCodec(Integer.class, 100, "NUMERIC");
         testCodec(Integer.class, 100, "FLOAT4");
         testCodec(Integer.class, 100, "FLOAT8");
@@ -289,6 +290,7 @@ abstract class AbstractCodecIntegrationTests extends AbstractIntegrationTests {
         testCodec(Long.class, 100L, "INT2");
         testCodec(Long.class, 100L, "INT4");
         testCodec(Long.class, 100L, "INT8");
+        testCodec(Long.class, 100L, "OID");
         testCodec(Long.class, 100L, "NUMERIC");
         testCodec(Long.class, 100L, "FLOAT4");
         testCodec(Long.class, 100L, "FLOAT8");


### PR DESCRIPTION
This PR just adds the `OID` data type to the supported numeric types. This allows PostgreSQL's `OID` type to be decoded as `Integer`, `Long`, etc. According to PostgreSQL [documentation ](https://www.postgresql.org/docs/current/datatype-oid.html), the `OID` type is implemented as an unsigned  four-byte integer, so there should be no problem using the `NumericAbstractCodec` on this type 🙂 