### PR TITLE
Prepared statement cache configuration

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/DisabledStatementCache.java
+++ b/src/main/java/io/r2dbc/postgresql/DisabledStatementCache.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.r2dbc.postgresql.client.Binding;
+import io.r2dbc.postgresql.client.Client;
+import io.r2dbc.postgresql.client.ExtendedQueryMessageFlow;
+import io.r2dbc.postgresql.util.Assert;
+import reactor.core.publisher.Mono;
+
+class DisabledStatementCache implements StatementCache {
+
+    private static final String UNNAMED_STATEMENT_NAME = "";
+
+    private final Client client;
+
+    DisabledStatementCache(Client client) {
+        this.client = Assert.requireNonNull(client, "client must not be null");
+    }
+
+    @Override
+    public Mono<String> getName(Binding binding, String sql) {
+        Assert.requireNonNull(binding, "binding must not be null");
+        Assert.requireNonNull(sql, "sql must not be null");
+        String name = UNNAMED_STATEMENT_NAME;
+
+        ExceptionFactory factory = ExceptionFactory.withSql(name);
+        return ExtendedQueryMessageFlow
+            .parse(this.client, name, sql, binding.getParameterTypes())
+            .handle(factory::handleErrorResponse)
+            .then(Mono.just(name));
+    }
+
+    @Override
+    public String toString() {
+        return "DisabledStatementCache{" +
+            "client=" + this.client +
+            '}';
+    }
+}

--- a/src/main/java/io/r2dbc/postgresql/LimitedStatementCache.java
+++ b/src/main/java/io/r2dbc/postgresql/LimitedStatementCache.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.r2dbc.postgresql.client.Binding;
+import io.r2dbc.postgresql.client.Client;
+import io.r2dbc.postgresql.client.ExtendedQueryMessageFlow;
+import io.r2dbc.postgresql.util.Assert;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LimitedStatementCache implements StatementCache {
+
+    private final LinkedHashMap<Tuple2<String, List<Integer>>, String> cache = new LinkedHashMap<>(16, 0.75f, true);
+
+    private final Client client;
+
+    private final AtomicInteger counter = new AtomicInteger();
+
+    private final int limit;
+
+    public LimitedStatementCache(Client client, int limit) {
+        this.client = Assert.requireNonNull(client, "client must not be null");
+        if (limit <= 0) {
+            throw new IllegalArgumentException("statement cache limit must be greater than zero");
+        }
+        this.limit = limit;
+    }
+
+    @Override
+    public Mono<String> getName(Binding binding, String sql) {
+        Assert.requireNonNull(binding, "binding must not be null");
+        Assert.requireNonNull(sql, "sql must not be null");
+        Tuple2<String, List<Integer>> key = Tuples.of(sql, binding.getParameterTypes());
+        String name = this.cache.get(key);
+        if (name != null) {
+            return Mono.just(name);
+        }
+
+        Mono<Void> closeLastStatement = Mono.defer(() -> {
+            if (this.cache.size() < this.limit) {
+                return Mono.empty();
+            }
+            String lastAccessedStatementName = this.cache.values().iterator().next();
+            ExceptionFactory factory = ExceptionFactory.withSql(lastAccessedStatementName);
+            return ExtendedQueryMessageFlow
+                .closeStatement(this.client, lastAccessedStatementName)
+                .handle(factory::handleErrorResponse)
+                .then();
+        });
+
+        return closeLastStatement.then(this.parse(sql, binding.getParameterTypes()))
+            .doOnNext(preparedName -> this.cache.put(key, preparedName));
+    }
+
+    @Override
+    public String toString() {
+        return "LimitedStatementCache{" +
+            "cache=" + this.cache +
+            ", counter=" + this.counter +
+            ", client=" + this.client +
+            ", limit=" + this.limit +
+            '}';
+    }
+
+    private Mono<String> parse(String sql, List<Integer> types) {
+        String name = String.format("S_%d", this.counter.getAndIncrement());
+
+        ExceptionFactory factory = ExceptionFactory.withSql(name);
+        return ExtendedQueryMessageFlow
+            .parse(this.client, name, sql, types)
+            .handle(factory::handleErrorResponse)
+            .then(Mono.just(name))
+            .cache();
+    }
+}

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionConfiguration.java
@@ -78,10 +78,12 @@ public final class PostgresqlConnectionConfiguration {
 
     private final SSLConfig sslConfig;
 
+    private final int preparedStatementCacheQueries;
+
     private PostgresqlConnectionConfiguration(String applicationName, boolean autodetectExtensions,
                                               @Nullable Duration connectTimeout, @Nullable String database, List<Extension> extensions, boolean forceBinary, @Nullable String host,
                                               @Nullable Map<String, String> options, @Nullable CharSequence password, int port, @Nullable String schema, @Nullable String socket, String username,
-                                              SSLConfig sslConfig) {
+                                              SSLConfig sslConfig, int preparedStatementCacheQueries) {
         this.applicationName = Assert.requireNonNull(applicationName, "applicationName must not be null");
         this.autodetectExtensions = autodetectExtensions;
         this.connectTimeout = connectTimeout;
@@ -96,6 +98,7 @@ public final class PostgresqlConnectionConfiguration {
         this.socket = socket;
         this.username = Assert.requireNonNull(username, "username must not be null");
         this.sslConfig = sslConfig;
+        this.preparedStatementCacheQueries = preparedStatementCacheQueries;
     }
 
     /**
@@ -215,6 +218,10 @@ public final class PostgresqlConnectionConfiguration {
         return this.sslConfig;
     }
 
+    int getPreparedStatementCacheQueries() {
+        return this.preparedStatementCacheQueries;
+    }
+
     private static String obfuscate(int length) {
 
         StringBuilder builder = new StringBuilder();
@@ -284,6 +291,8 @@ public final class PostgresqlConnectionConfiguration {
         @Nullable
         private String username;
 
+        private int preparedStatementCacheQueries = -1;
+
         private Builder() {
         }
 
@@ -330,7 +339,7 @@ public final class PostgresqlConnectionConfiguration {
             }
 
             return new PostgresqlConnectionConfiguration(this.applicationName, this.autodetectExtensions, this.connectTimeout, this.database, this.extensions, this.forceBinary, this.host,
-                this.options, this.password, this.port, this.schema, this.socket, this.username, this.createSslConfig());
+                this.options, this.password, this.port, this.schema, this.socket, this.username, this.createSslConfig(), this.preparedStatementCacheQueries);
         }
 
         /**
@@ -569,6 +578,18 @@ public final class PostgresqlConnectionConfiguration {
             return this;
         }
 
+        /**
+         * Configure the preparedStatementCacheQueries.
+         *
+         * @param preparedStatementCacheQueries the preparedStatementCacheQueries
+         * @return this {@link Builder}
+         * @throws IllegalArgumentException if {@code username} is {@code null}
+         */
+        public Builder preparedStatementCacheQueries(int preparedStatementCacheQueries) {
+            this.preparedStatementCacheQueries = preparedStatementCacheQueries;
+            return this;
+        }
+
         @Override
         public String toString() {
             return "Builder{" +
@@ -591,6 +612,7 @@ public final class PostgresqlConnectionConfiguration {
                 ", sslCert='" + this.sslCert + '\'' +
                 ", sslKey='" + this.sslKey + '\'' +
                 ", sslHostnameVerifier='" + this.sslHostnameVerifier + '\'' +
+                ", preparedStatementCacheQueries='" + this.preparedStatementCacheQueries + '\'' +
                 '}';
         }
 

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
@@ -169,8 +169,10 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
                     isolationLevelMono = getIsolationLevel(client, codecs);
                 }
 
+                StatementCache statementCache = StatementCache.fromPreparedStatementCacheQueries(client, this.configuration.getPreparedStatementCacheQueries());
+
                 return isolationLevelMono
-                    .map(it -> new PostgresqlConnection(client, codecs, DefaultPortalNameSupplier.INSTANCE, new IndefiniteStatementCache(client), it, this.configuration.isForceBinary()))
+                    .map(it -> new PostgresqlConnection(client, codecs, DefaultPortalNameSupplier.INSTANCE, statementCache, it, this.configuration.isForceBinary()))
                     .delayUntil(connection -> {
                         return prepareConnection(connection, client.getByteBufAllocator(), codecs);
                     })

--- a/src/main/java/io/r2dbc/postgresql/StatementCache.java
+++ b/src/main/java/io/r2dbc/postgresql/StatementCache.java
@@ -17,10 +17,20 @@
 package io.r2dbc.postgresql;
 
 import io.r2dbc.postgresql.client.Binding;
+import io.r2dbc.postgresql.client.Client;
 import reactor.core.publisher.Mono;
 
 interface StatementCache {
 
     Mono<String> getName(Binding binding, String sql);
 
+    static StatementCache fromPreparedStatementCacheQueries(Client client, int preparedStatementCacheQueries) {
+        if (preparedStatementCacheQueries < 0) {
+            return new IndefiniteStatementCache(client);
+        }
+        if (preparedStatementCacheQueries == 0) {
+            return new DisabledStatementCache(client);
+        }
+        return new LimitedStatementCache(client, preparedStatementCacheQueries);
+    }
 }

--- a/src/main/java/io/r2dbc/postgresql/client/Client.java
+++ b/src/main/java/io/r2dbc/postgresql/client/Client.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * An abstraction that wraps the networking part of exchanging methods.
@@ -57,7 +58,18 @@ public interface Client {
      * @return a {@link Flux} of incoming messages that ends with the end of the frame (i.e. reception of a {@link ReadyForQuery} message.
      * @throws IllegalArgumentException if {@code requests} is {@code null}
      */
-    Flux<BackendMessage> exchange(Publisher<FrontendMessage> requests);
+    default Flux<BackendMessage> exchange(Publisher<FrontendMessage> requests) {
+        return this.exchange(it -> it.getClass() == ReadyForQuery.class, requests);
+    }
+
+    /**
+     * Perform an exchange of messages.
+     *
+     * @param requests the publisher of outbound messages
+     * @return a {@link Flux} of incoming messages that ends with the end of the frame (i.e. reception of a {@link ReadyForQuery} message.
+     * @throws IllegalArgumentException if {@code requests} is {@code null}
+     */
+    Flux<BackendMessage> exchange(Predicate<BackendMessage> takeUntil, Publisher<FrontendMessage> requests);
 
     /**
      * Returns the {@link ByteBufAllocator}.

--- a/src/main/java/io/r2dbc/postgresql/client/Client.java
+++ b/src/main/java/io/r2dbc/postgresql/client/Client.java
@@ -72,6 +72,14 @@ public interface Client {
     Flux<BackendMessage> exchange(Predicate<BackendMessage> takeUntil, Publisher<FrontendMessage> requests);
 
     /**
+     * Send one message without waiting for response.
+     *
+     * @param message outbound message
+     * @throws IllegalArgumentException if {@code message} is {@code null}
+     */
+    void send(FrontendMessage message);
+
+    /**
      * Returns the {@link ByteBufAllocator}.
      *
      * @return the {@link ByteBufAllocator}

--- a/src/main/java/io/r2dbc/postgresql/client/ExtendedQueryMessageFlow.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ExtendedQueryMessageFlow.java
@@ -19,12 +19,14 @@ package io.r2dbc.postgresql.client;
 import io.netty.buffer.Unpooled;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.message.backend.BackendMessage;
-import io.r2dbc.postgresql.message.backend.NoData;
-import io.r2dbc.postgresql.message.backend.RowDescription;
+import io.r2dbc.postgresql.message.backend.CloseComplete;
+import io.r2dbc.postgresql.message.backend.ParseComplete;
 import io.r2dbc.postgresql.message.frontend.Bind;
 import io.r2dbc.postgresql.message.frontend.Close;
 import io.r2dbc.postgresql.message.frontend.Describe;
 import io.r2dbc.postgresql.message.frontend.Execute;
+import io.r2dbc.postgresql.message.frontend.ExecutionType;
+import io.r2dbc.postgresql.message.frontend.Flush;
 import io.r2dbc.postgresql.message.frontend.FrontendMessage;
 import io.r2dbc.postgresql.message.frontend.Parse;
 import io.r2dbc.postgresql.message.frontend.Sync;
@@ -36,13 +38,10 @@ import reactor.core.publisher.Mono;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static io.r2dbc.postgresql.message.frontend.Execute.NO_LIMIT;
 import static io.r2dbc.postgresql.message.frontend.ExecutionType.PORTAL;
-import static io.r2dbc.postgresql.message.frontend.ExecutionType.STATEMENT;
-import static io.r2dbc.postgresql.util.PredicateUtils.or;
 
 /**
  * A utility class that encapsulates the <a href="https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY">Extended query</a> message flow.
@@ -53,8 +52,6 @@ public final class ExtendedQueryMessageFlow {
      * The pattern that identifies a parameter symbol.
      */
     public static final Pattern PARAMETER_SYMBOL = Pattern.compile("\\$([\\d]+)", Pattern.DOTALL);
-
-    private static final Predicate<BackendMessage> TAKE_UNTIL = or(RowDescription.class::isInstance, NoData.class::isInstance);
 
     private ExtendedQueryMessageFlow() {
     }
@@ -98,8 +95,23 @@ public final class ExtendedQueryMessageFlow {
         Assert.requireNonNull(query, "query must not be null");
         Assert.requireNonNull(types, "types must not be null");
 
-        return client.exchange(Flux.just(new Parse(name, types, query), new Describe(name, STATEMENT), Sync.INSTANCE))
-            .takeUntil(TAKE_UNTIL);
+        return client.exchange(ParseComplete.class::isInstance, Flux.just(new Parse(name, types, query), Flush.INSTANCE));
+    }
+
+    /**
+     * Execute the close portion of the <a href="https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY">Extended query</a> message flow.
+     *
+     * @param client the {@link Client} to exchange messages with
+     * @param name   the name of the statement to close
+     * @return the messages received in response to this exchange
+     * @throws IllegalArgumentException if {@code client}, {@code name}, {@code query}, or {@code types} is {@code null}
+     */
+    public static Flux<BackendMessage> closeStatement(Client client, String name) {
+        Assert.requireNonNull(client, "client must not be null");
+        Assert.requireNonNull(name, "name must not be null");
+
+        return client.exchange(Flux.just(new Close(name, ExecutionType.STATEMENT), Sync.INSTANCE))
+            .takeUntil(CloseComplete.class::isInstance);
     }
 
     private static Collection<Format> resultFormat(boolean forceBinary) {

--- a/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
@@ -52,7 +52,6 @@ import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.MonoSink;
 import reactor.core.publisher.SynchronousSink;
 import reactor.netty.Connection;
 import reactor.netty.resources.ConnectionProvider;
@@ -76,7 +75,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static io.r2dbc.postgresql.client.TransactionStatus.IDLE;
@@ -104,7 +103,7 @@ public final class ReactorNettyClient implements Client {
 
     private final FluxSink<FrontendMessage> requests = this.requestProcessor.sink();
 
-    private final Queue<MonoSink<Flux<BackendMessage>>> responseReceivers = Queues.<MonoSink<Flux<BackendMessage>>>unbounded().get();
+    private final Queue<ResponseReceiver> responseReceivers = Queues.<ResponseReceiver>unbounded().get();
 
     private final DirectProcessor<NotificationResponse> notificationProcessor = DirectProcessor.create();
 
@@ -140,21 +139,15 @@ public final class ReactorNettyClient implements Client {
                 receiveError.set(throwable);
                 handleConnectionError(throwable);
             })
-            .windowWhile(it -> it.getClass() != ReadyForQuery.class)
-            .doOnNext(fluxOfMessages -> {
-                MonoSink<Flux<BackendMessage>> receiver = this.responseReceivers.poll();
+            .handle((message, sink) -> {
+                ResponseReceiver receiver = this.responseReceivers.peek();
                 if (receiver != null) {
-                    receiver.success(fluxOfMessages.doOnComplete(() -> {
-
-                        Throwable throwable = receiveError.get();
-                        if (throwable != null) {
-                            throw new PostgresConnectionException(throwable);
-                        }
-
-                        if (!isConnected()) {
-                            throw EXPECTED.get();
-                        }
-                    }));
+                    if (receiver.takeUntil.test(message)) {
+                        receiver.sink.complete();
+                        this.responseReceivers.poll();
+                    } else {
+                        receiver.sink.next(message);
+                    }
                 }
             })
             .doOnComplete(this::handleClose)
@@ -177,6 +170,43 @@ public final class ReactorNettyClient implements Client {
             .onErrorResume(this::resumeError)
             .doAfterTerminate(this::handleClose)
             .subscribe();
+    }
+
+    @Override
+    public Flux<BackendMessage> exchange(Predicate<BackendMessage> takeUntil, Publisher<FrontendMessage> requests) {
+        Assert.requireNonNull(requests, "requests must not be null");
+
+        return Flux
+            .create(sink -> {
+
+                final AtomicInteger once = new AtomicInteger();
+
+                Flux.from(requests)
+                    .subscribe(message -> {
+
+                        if (!isConnected()) {
+                            ReferenceCountUtil.safeRelease(message);
+                            sink.error(new PostgresConnectionClosedException("Cannot exchange messages because the connection is closed"));
+                            return;
+                        }
+
+                        if (once.get() == 0 && once.compareAndSet(0, 1)) {
+                            synchronized (this) {
+                                this.responseReceivers.add(new ResponseReceiver(sink, takeUntil));
+                                this.requests.next(message);
+                            }
+                        } else {
+                            this.requests.next(message);
+                        }
+
+                    }, this.requests::error, () -> {
+
+                        if (!isConnected()) {
+                            sink.error(new PostgresConnectionClosedException("Cannot exchange messages because the connection is closed"));
+                        }
+                    });
+
+            });
     }
 
     private Mono<Void> resumeError(Throwable throwable) {
@@ -357,42 +387,12 @@ public final class ReactorNettyClient implements Client {
         });
     }
 
-    @Override
-    public Flux<BackendMessage> exchange(Publisher<FrontendMessage> requests) {
-        Assert.requireNonNull(requests, "requests must not be null");
+    private void drainError(Supplier<? extends Throwable> supplier) {
+        ResponseReceiver receiver;
 
-        return Mono
-            .<Flux<BackendMessage>>create(sink -> {
-
-                final AtomicInteger once = new AtomicInteger();
-
-                Flux.from(requests)
-                    .subscribe(message -> {
-
-                        if (!isConnected()) {
-                            ReferenceCountUtil.safeRelease(message);
-                            sink.error(new PostgresConnectionClosedException("Cannot exchange messages because the connection is closed"));
-                            return;
-                        }
-
-                        if (once.get() == 0 && once.compareAndSet(0, 1)) {
-                            synchronized (this) {
-                                this.responseReceivers.add(sink);
-                                this.requests.next(message);
-                            }
-                        } else {
-                            this.requests.next(message);
-                        }
-
-                    }, this.requests::error, () -> {
-
-                        if (!isConnected()) {
-                            sink.error(new PostgresConnectionClosedException("Cannot exchange messages because the connection is closed"));
-                        }
-                    });
-
-            })
-            .flatMapMany(Function.identity());
+        while ((receiver = this.responseReceivers.poll()) != null) {
+            receiver.sink.error(supplier.get());
+        }
     }
 
     @Override
@@ -461,11 +461,15 @@ public final class ReactorNettyClient implements Client {
         drainError(() -> new PostgresConnectionException(error));
     }
 
-    private void drainError(Supplier<? extends Throwable> supplier) {
-        MonoSink<Flux<BackendMessage>> receiver;
+    private static class ResponseReceiver {
 
-        while ((receiver = this.responseReceivers.poll()) != null) {
-            receiver.error(supplier.get());
+        private final FluxSink<BackendMessage> sink;
+
+        private final Predicate<BackendMessage> takeUntil;
+
+        private ResponseReceiver(FluxSink<BackendMessage> sink, Predicate<BackendMessage> takeUntil) {
+            this.sink = sink;
+            this.takeUntil = takeUntil;
         }
     }
 

--- a/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
@@ -209,6 +209,13 @@ public final class ReactorNettyClient implements Client {
             });
     }
 
+    @Override
+    public void send(FrontendMessage message) {
+        Assert.requireNonNull(message, "requests must not be null");
+
+        this.requests.next(message);
+    }
+
     private Mono<Void> resumeError(Throwable throwable) {
 
         handleConnectionError(throwable);

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
@@ -30,6 +30,7 @@ import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.FORCE_BINA
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.LEGACY_POSTGRESQL_DRIVER;
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.OPTIONS;
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.POSTGRESQL_DRIVER;
+import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.PREPARED_STATEMENT_CACHE_QUERIES;
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.SOCKET;
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.SSL_CONTEXT_BUILDER_CUSTOMIZER;
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.SSL_MODE;
@@ -175,6 +176,32 @@ final class PostgresqlConnectionFactoryProviderTest {
             .build());
 
         assertThat(factory.getConfiguration().isForceBinary()).isTrue();
+    }
+
+    @Test
+    void providerShouldConsiderPreparedStatementCacheQueries() {
+        PostgresqlConnectionFactory factory = this.provider.create(builder()
+            .option(DRIVER, LEGACY_POSTGRESQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(PASSWORD, "test-password")
+            .option(USER, "test-user")
+            .option(PREPARED_STATEMENT_CACHE_QUERIES, -1)
+            .build());
+
+        assertThat(factory.getConfiguration().getPreparedStatementCacheQueries()).isEqualTo(-1);
+    }
+
+    @Test
+    void providerShouldConsiderPreparedStatementCacheQueriesWhenProvidedAsString() {
+        PostgresqlConnectionFactory factory = this.provider.create(builder()
+            .option(DRIVER, LEGACY_POSTGRESQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(PASSWORD, "test-password")
+            .option(USER, "test-user")
+            .option(Option.valueOf("preparedStatementCacheQueries"), "-1")
+            .build());
+
+        assertThat(factory.getConfiguration().getPreparedStatementCacheQueries()).isEqualTo(-1);
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/client/ReactorNettyClientIntegrationTests.java
@@ -21,7 +21,9 @@ import io.netty.channel.kqueue.KQueue;
 import io.netty.util.ReferenceCountUtil;
 import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
 import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import io.r2dbc.postgresql.api.ErrorDetails;
 import io.r2dbc.postgresql.api.PostgresqlConnection;
+import io.r2dbc.postgresql.api.PostgresqlException;
 import io.r2dbc.postgresql.authentication.PasswordAuthenticationHandler;
 import io.r2dbc.postgresql.message.backend.BackendMessage;
 import io.r2dbc.postgresql.message.backend.CommandComplete;
@@ -30,7 +32,9 @@ import io.r2dbc.postgresql.message.backend.NotificationResponse;
 import io.r2dbc.postgresql.message.backend.RowDescription;
 import io.r2dbc.postgresql.message.frontend.FrontendMessage;
 import io.r2dbc.postgresql.message.frontend.Query;
+import io.r2dbc.postgresql.util.PgBouncer;
 import io.r2dbc.postgresql.util.PostgresqlServerExtension;
+import io.r2dbc.spi.R2dbcBadGrammarException;
 import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
 import org.junit.jupiter.api.AfterEach;
@@ -336,29 +340,77 @@ final class ReactorNettyClientIntegrationTests {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    final class StatementCacheSizeTests {
+    final class PgBouncerTests {
 
         @ParameterizedTest
-        @ValueSource(ints = {0, 2, -1})
-        void multiplePreparedStatementsTest(int statementCacheSize) {
-            PostgresqlConnectionFactory connectionFactory = this.createConnectionFactory(statementCacheSize);
+        @ValueSource(strings = {"transaction", "statement"})
+        void disabledCacheWorksWithTransactionAndStatementModes(String poolMode) {
+            try (PgBouncer pgBouncer = new PgBouncer(SERVER, poolMode)) {
+                PostgresqlConnectionFactory connectionFactory = this.createConnectionFactory(pgBouncer, 0);
 
-            connectionFactory.create().flatMapMany(connection -> {
-                Flux<Integer> firstQuery = connection.createStatement("SELECT 1 WHERE $1 = 1").bind(0, 1).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
-                Flux<Integer> secondQuery = connection.createStatement("SELECT 2 WHERE $1 = 2").bind(0, 2).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
-                Flux<Integer> thirdQuery = connection.createStatement("SELECT 3 WHERE $1 = 3").bind(0, 3).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
+                connectionFactory.create().flatMapMany(connection -> {
+                    Flux<Integer> q1 = connection.createStatement("SELECT 1 WHERE $1 = 1").bind(0, 1).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
+                    Flux<Integer> q2 = connection.createStatement("SELECT 2 WHERE $1 = 2").bind(0, 2).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
+                    Flux<Integer> q3 = connection.createStatement("SELECT 3 WHERE $1 = 3").bind(0, 3).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
 
-                return Flux.concat(firstQuery, secondQuery, thirdQuery, connection.close());
-            })
-                .as(StepVerifier::create)
-                .expectNext(1, 2, 3)
-                .verifyComplete();
+                    return Flux.concat(q1, q1, q2, q2, q3, q3, connection.close());
+                })
+                    .as(StepVerifier::create)
+                    .expectNext(1, 1, 2, 2, 3, 3)
+                    .verifyComplete();
+            }
         }
 
-        private PostgresqlConnectionFactory createConnectionFactory(int statementCacheSize) {
+        @ParameterizedTest
+        @ValueSource(ints = {-1, 0, 2})
+        void sessionModeWorksWithAllCaches(int statementCacheSize) {
+            try (PgBouncer pgBouncer = new PgBouncer(SERVER, "session")) {
+                PostgresqlConnectionFactory connectionFactory = this.createConnectionFactory(pgBouncer, statementCacheSize);
+
+                connectionFactory.create().flatMapMany(connection -> {
+                    Flux<Integer> q1 = connection.createStatement("SELECT 1 WHERE $1 = 1").bind(0, 1).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
+                    Flux<Integer> q2 = connection.createStatement("SELECT 2 WHERE $1 = 2").bind(0, 2).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
+                    Flux<Integer> q3 = connection.createStatement("SELECT 3 WHERE $1 = 3").bind(0, 3).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
+
+                    return Flux.concat(q1, q1, q2, q2, q3, q3, connection.close());
+                })
+                    .as(StepVerifier::create)
+                    .expectNext(1, 1, 2, 2, 3, 3)
+                    .verifyComplete();
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"transaction", "statement"})
+        void statementCacheDoesntWorkWithTransactionAndStatementModes(String poolMode) {
+            try (PgBouncer pgBouncer = new PgBouncer(SERVER, poolMode)) {
+                PostgresqlConnectionFactory connectionFactory = this.createConnectionFactory(pgBouncer, -1);
+
+                connectionFactory.create().flatMapMany(connection -> {
+                    Flux<Integer> q1 = connection.createStatement("SELECT 1 WHERE $1 = 1").bind(0, 1).execute().flatMap(r -> r.map((row, rowMetadata) -> row.get(0, Integer.class)));
+
+                    return Flux.concat(q1, q1, connection.close());
+                })
+                    .as(StepVerifier::create)
+                    .expectNext(1)
+                    .verifyErrorMatches(e -> {
+                        if (!(e instanceof R2dbcBadGrammarException)) {
+                            return false;
+                        }
+                        if (!(e instanceof PostgresqlException)) {
+                            return false;
+                        }
+                        PostgresqlException pgException = (PostgresqlException) e;
+                        ErrorDetails errorDetails = pgException.getErrorDetails();
+                        return errorDetails.getCode().equals("26000") && errorDetails.getMessage().equals("prepared statement \"S_0\" does not exist");
+                    });
+            }
+        }
+
+        private PostgresqlConnectionFactory createConnectionFactory(PgBouncer pgBouncer, int statementCacheSize) {
             return new PostgresqlConnectionFactory(PostgresqlConnectionConfiguration.builder()
-                .host(SERVER.getHost())
-                .port(SERVER.getPort())
+                .host(pgBouncer.getHost())
+                .port(pgBouncer.getPort())
                 .username(SERVER.getUsername())
                 .password(SERVER.getPassword())
                 .database(SERVER.getDatabase())

--- a/src/test/java/io/r2dbc/postgresql/client/TestClient.java
+++ b/src/test/java/io/r2dbc/postgresql/client/TestClient.java
@@ -119,7 +119,8 @@ public final class TestClient implements Client {
                 Flux.from(requests)
                     .subscribe(this.requests::next, this.requests::error))
             .next()
-            .flatMapMany(Function.identity());
+            .flatMapMany(Function.identity())
+            .takeWhile(takeUntil.negate());
     }
 
     @Override
@@ -150,6 +151,11 @@ public final class TestClient implements Client {
     @Override
     public boolean isConnected() {
         return this.connected;
+    }
+
+    @Override
+    public void send(FrontendMessage message) {
+        this.requests.next(message);
     }
 
     @Override

--- a/src/test/java/io/r2dbc/postgresql/util/PgBouncer.java
+++ b/src/test/java/io/r2dbc/postgresql/util/PgBouncer.java
@@ -1,0 +1,39 @@
+package io.r2dbc.postgresql.util;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+
+public class PgBouncer implements AutoCloseable {
+
+    private final GenericContainer<?> container;
+
+    public PgBouncer(PostgresqlServerExtension server, String poolMode) {
+        this.container = new GenericContainer<>("edoburu/pgbouncer")
+            .withExposedPorts(PostgreSQLContainer.POSTGRESQL_PORT)
+            .withEnv("POOL_MODE", poolMode)
+            .withEnv("SERVER_RESET_QUERY_ALWAYS", "1")
+            .withEnv("DB_USER", server.getUsername())
+            .withEnv("DB_PASSWORD", server.getPassword())
+            .withEnv("DB_HOST", server.getPostgres().getNetworkAlias())
+            .withEnv("DB_PORT", String.valueOf(PostgreSQLContainer.POSTGRESQL_PORT))
+            .withEnv("DB_NAME", server.getDatabase())
+            .waitingFor(new HostPortWaitStrategy())
+            .withNetwork(server.getPostgres().getNetwork());
+
+        this.container.start();
+    }
+
+    @Override
+    public void close() {
+        this.container.stop();
+    }
+
+    public String getHost() {
+        return this.container.getContainerIpAddress();
+    }
+
+    public int getPort() {
+        return this.container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT);
+    }
+}


### PR DESCRIPTION
https://github.com/r2dbc/r2dbc-postgresql/issues/223

Added preparedStatementCacheQueries parameter, which controls cache behaviour.
When cache limit is reached last used statement is closed before parsing new one.
When cache limit is 0 caching of statement is disabled and unnamed statements are used in extended message flow.
Negative values stand for IndefiniteStatementCache (default one).

