### PR TITLE
Add DiscardOnCancel operator

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
+++ b/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.r2dbc.postgresql;
 
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
 import io.r2dbc.postgresql.api.PostgresqlStatement;
 import io.r2dbc.postgresql.client.Binding;
 import io.r2dbc.postgresql.client.Client;
@@ -28,6 +30,7 @@ import io.r2dbc.postgresql.message.backend.CloseComplete;
 import io.r2dbc.postgresql.message.backend.NoData;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.GeneratedValuesUtils;
+import io.r2dbc.postgresql.util.Operators;
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
@@ -182,11 +185,16 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
 
         ExceptionFactory factory = ExceptionFactory.withSql(sql);
         return this.statementCache.getName(this.bindings.first(), sql)
-            .flatMapMany(name -> ExtendedQueryMessageFlow
-                .execute(Flux.fromIterable(this.bindings.bindings), this.client, this.portalNameSupplier, name, sql, this.forceBinary))
+            .flatMapMany(name -> {
+                return ExtendedQueryMessageFlow
+                    .execute(Flux.fromIterable(this.bindings.bindings), this.client, this.portalNameSupplier, name, sql, this.forceBinary);
+            })
             .filter(RESULT_FRAME_FILTER)
             .windowUntil(CloseComplete.class::isInstance)
-            .map(messages -> PostgresqlResult.toResult(this.codecs, messages, factory));
+            .map(messages -> PostgresqlResult.toResult(this.codecs, messages, factory))
+            .cast(io.r2dbc.postgresql.api.PostgresqlResult.class)
+            .as(Operators::discardOnCancel)
+            .doOnDiscard(ReferenceCounted.class, ReferenceCountUtil::release);
     }
 
     private int getIndex(String identifier) {

--- a/src/main/java/io/r2dbc/postgresql/client/ExtendedQueryMessageFlow.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ExtendedQueryMessageFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/postgresql/client/ReactorNettyClient.java
@@ -29,6 +29,7 @@ import io.netty.channel.socket.DatagramChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.r2dbc.postgresql.message.backend.BackendKeyData;
@@ -145,7 +146,12 @@ public final class ReactorNettyClient implements Client {
                         receiver.sink.complete();
                         this.conversations.poll();
                     } else {
-                        receiver.sink.next(message);
+
+                        if (receiver.sink.isCancelled()) {
+                            ReferenceCountUtil.release(message);
+                        } else {
+                            receiver.sink.next(message);
+                        }
                     }
                 }
             })

--- a/src/main/java/io/r2dbc/postgresql/util/FluxDiscardOnCancel.java
+++ b/src/main/java/io/r2dbc/postgresql/util/FluxDiscardOnCancel.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.util;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxOperator;
+import reactor.core.publisher.Operators;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+import reactor.util.context.Context;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A decorating operator that replays signals from its source to a {@link Subscriber} and drains the source upon {@link Subscription#cancel() cancel} and drops data signals until termination.
+ * Draining data is required to complete a particular request/response window and clear the protocol state as client code expects to start a request/response conversation without any previous
+ * response state.
+ */
+class FluxDiscardOnCancel<T> extends FluxOperator<T, T> {
+
+    private static final Logger logger = Loggers.getLogger(FluxDiscardOnCancel.class);
+
+    private final Runnable cancelConsumer;
+
+    FluxDiscardOnCancel(Flux<? extends T> source, Runnable cancelConsumer) {
+        super(source);
+        this.cancelConsumer = cancelConsumer;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        this.source.subscribe(new FluxDiscardOnCancelSubscriber<>(actual, this.cancelConsumer));
+    }
+
+    static class FluxDiscardOnCancelSubscriber<T> extends AtomicBoolean implements CoreSubscriber<T>, Subscription {
+
+        final CoreSubscriber<T> actual;
+
+        final Context ctx;
+
+        final Runnable cancelConsumer;
+
+        Subscription s;
+
+        FluxDiscardOnCancelSubscriber(CoreSubscriber<T> actual, Runnable cancelConsumer) {
+
+            this.actual = actual;
+            this.ctx = actual.currentContext();
+            this.cancelConsumer = cancelConsumer;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+
+            if (Operators.validate(this.s, s)) {
+                this.s = s;
+                this.actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+
+            if (this.get()) {
+                Operators.onDiscard(t, this.ctx);
+                return;
+            }
+
+            this.actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (this.get()) {
+                Operators.onErrorDropped(t, this.ctx);
+            } else {
+                this.actual.onError(t);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (!this.get()) {
+                this.actual.onComplete();
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            this.s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+
+            if (compareAndSet(false, true)) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("received cancel signal");
+                }
+                try {
+                    this.cancelConsumer.run();
+                } catch (Exception e) {
+                    Operators.onErrorDropped(e, this.ctx);
+                }
+                this.s.request(Long.MAX_VALUE);
+            }
+        }
+    }
+}

--- a/src/main/java/io/r2dbc/postgresql/util/Operators.java
+++ b/src/main/java/io/r2dbc/postgresql/util/Operators.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.util;
+
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.Flux;
+
+/**
+ * Operator utility.
+ *
+ * @since 0.8.1
+ */
+public final class Operators {
+
+    private Operators() {
+    }
+
+    /**
+     * Replay signals from {@link Flux the source} until cancellation. Drains the source for data signals if the subscriber cancels the subscription.
+     * <p>
+     * Draining data is required to complete a particular request/response window and clear the protocol state as client code expects to start a request/response conversation without leaving
+     * previous frames on the stack.
+     *
+     * @param source the source to decorate.
+     * @param <T>    The type of values in both source and output sequences.
+     * @return decorated {@link Flux}.
+     */
+    public static <T> Flux<T> discardOnCancel(Flux<? extends T> source) {
+        return new FluxDiscardOnCancel<>(source, () -> {
+        });
+    }
+
+    /**
+     * Replay signals from {@link Flux the source} until cancellation. Drains the source for data signals if the subscriber cancels the subscription.
+     * <p>
+     * Draining data is required to complete a particular request/response window and clear the protocol state as client code expects to start a request/response conversation without leaving
+     * previous frames on the stack.
+     * <p>Propagates the {@link Subscription#cancel()}  signal to a {@link Runnable consumer}.
+     *
+     * @param source         the source to decorate.
+     * @param cancelConsumer {@link Runnable} notified when the resulting {@link Flux} receives a {@link Subscription#cancel() cancel} signal.
+     * @param <T>            The type of values in both source and output sequences.
+     * @return decorated {@link Flux}.
+     */
+    public static <T> Flux<T> discardOnCancel(Flux<? extends T> source, Runnable cancelConsumer) {
+        return new FluxDiscardOnCancel<>(source, cancelConsumer);
+    }
+}

--- a/src/test/java/io/r2dbc/postgresql/PostgresCancelIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresCancelIntegrationTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for cancellation.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PostgresCancelIntegrationTests extends AbstractIntegrationTests {
+
+    static final int NUMBER_REPETITIONS = 300;
+
+    @Override
+    @BeforeAll
+    void setUp() {
+
+        super.setUp();
+
+        SERVER.getJdbcOperations().execute("DROP TABLE IF EXISTS insert_test;");
+        SERVER.getJdbcOperations().execute("CREATE TABLE insert_test\n" +
+            "(\n" +
+            "    id    SERIAL PRIMARY KEY,\n" +
+            "    value CHAR(1) NOT NULL\n" +
+            ");");
+    }
+
+    @AfterAll
+    void tearDown() {
+        super.tearDown();
+    }
+
+    @Test
+    void shouldBeginAndCommitCancel() throws InterruptedException {
+
+        // precondition
+        assertThat(this.connection.isAutoCommit()).isTrue();
+
+        this.connection.beginTransaction().then(this.connection.commitTransaction())
+            .as(StepVerifier::create)
+            .thenCancel()
+            .verify();
+
+
+        // await completion
+        Thread.sleep(100);
+
+        assertThat(this.connection.isAutoCommit()).isTrue();
+    }
+
+    @RepeatedTest(NUMBER_REPETITIONS)
+    void shouldCancelSimpleQuery() {
+
+        this.connection.createStatement("INSERT INTO insert_test (value) VALUES('a')")
+            .returnGeneratedValues()
+            .execute().flatMap(postgresqlResult -> postgresqlResult.map((row, rowMetadata) -> row.get(0)), 1, 1)
+            .next()
+            .as(StepVerifier::create)
+            .expectNextCount(1)
+            .thenCancel()
+            .verify();
+    }
+
+    @RepeatedTest(NUMBER_REPETITIONS)
+    void shouldCancelParametrizedQuery() {
+
+        this.connection.createStatement("INSERT INTO insert_test (value) VALUES($1)")
+            .returnGeneratedValues()
+            .bind("$1", "a")
+            .execute().flatMap(postgresqlResult -> postgresqlResult.map((row, rowMetadata) -> row.get(0)), 1, 1)
+            .next()
+            .as(StepVerifier::create)
+            .expectNextCount(1)
+            .thenCancel()
+            .verify();
+    }
+
+    @RepeatedTest(NUMBER_REPETITIONS)
+    void shouldCancelParametrizedWithMultipleBindingsQuery() {
+
+        this.connection.createStatement("INSERT INTO insert_test (value) VALUES($1)")
+            .returnGeneratedValues()
+            .bind("$1", "a").add()
+            .bind("$1", "b")
+            .execute().flatMap(postgresqlResult -> postgresqlResult.map((row, rowMetadata) -> row.get(0)), 1, 1)
+            .next()
+            .as(StepVerifier::create)
+            .expectNextCount(1)
+            .thenCancel()
+            .verify();
+    }
+}

--- a/src/test/java/io/r2dbc/postgresql/util/FluxDiscardOnCancelUnitTests.java
+++ b/src/test/java/io/r2dbc/postgresql/util/FluxDiscardOnCancelUnitTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.util;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link FluxDiscardOnCancel}.
+ */
+class FluxDiscardOnCancelUnitTests {
+
+    @Test
+    void shouldEmitAllItemsOnSubscription() {
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(Operators::discardOnCancel)
+            .as(StepVerifier::create)
+            .expectNext(0, 1, 2, 3)
+            .verifyComplete();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void considersAssemblyHook() {
+
+        List<Object> publishers = new ArrayList<>();
+        Hooks.onEachOperator(objectPublisher -> {
+            publishers.add(objectPublisher);
+
+            return objectPublisher;
+        });
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .transform(Operators::discardOnCancel)
+            .as(StepVerifier::create)
+            .expectNextCount(4)
+            .verifyComplete();
+
+        assertThat(publishers).hasSize(2).extracting(Object::getClass).contains((Class) FluxDiscardOnCancel.class);
+    }
+
+    @Test
+    void considersOnDropHook() {
+
+        List<Object> discard = new ArrayList<>();
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(Operators::discardOnCancel)
+            .doOnDiscard(Object.class, discard::add)
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(2)
+            .expectNext(0, 1)
+            .thenCancel()
+            .verify();
+
+        assertThat(discard).containsOnly(2, 3);
+    }
+
+    @Test
+    void considersCancelSignalPropagation() {
+
+        AtomicBoolean cancelled = new AtomicBoolean();
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(it -> Operators.discardOnCancel(it, () -> cancelled.set(true)))
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(2)
+            .expectNext(0, 1)
+            .thenCancel()
+            .verify();
+
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    void shouldNotConsumeItemsOnCancel() {
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(2)
+            .expectNext(0, 1)
+            .thenCancel()
+            .verify();
+
+        assertThat(items).toIterable().containsSequence(2, 3);
+    }
+
+    @Test
+    void shouldConsumeAndDiscardItemsOnCancel() {
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(Operators::discardOnCancel)
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(2)
+            .expectNext(0, 1)
+            .thenCancel()
+            .verify();
+
+        assertThat(items).toIterable().isEmpty();
+    }
+
+    static Iterator<Integer> createItems(int count) {
+        return IntStream.range(0, count).boxed().iterator();
+    }
+}


### PR DESCRIPTION
FluxDiscardOnCancel replays source signals unless cancelling
the subscription. On cancellation, the subscriber requests Long.MAX_VALUE
to drain the source and discard elements that are emitted afterwards.

[closes #222]

/cc @squiry