### PR TITLE
Add support for RefCursor

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/ConnectionContext.java
+++ b/src/main/java/io/r2dbc/postgresql/ConnectionContext.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.r2dbc.postgresql.api.PostgresqlConnection;
+import io.r2dbc.postgresql.client.Client;
+import io.r2dbc.postgresql.codec.Codecs;
+
+/**
+ * @author Mark Paluch
+ */
+final class ConnectionContext {
+
+    private final Client client;
+
+    private final Codecs codecs;
+
+    private final PostgresqlConnection connection;
+
+    ConnectionContext(Client client, Codecs codecs, PostgresqlConnection connection) {
+        this.client = client;
+        this.codecs = codecs;
+        this.connection = connection;
+    }
+
+    public Client getClient() {
+        return this.client;
+    }
+
+    public Codecs getCodecs() {
+        return this.codecs;
+    }
+
+    public PostgresqlConnection getConnection() {
+        return this.connection;
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectionContext{" +
+            "client=" + this.client +
+            ", codecs=" + this.codecs +
+            ", connection=" + this.connection +
+            '}';
+    }
+}

--- a/src/main/java/io/r2dbc/postgresql/ConnectionContext.java
+++ b/src/main/java/io/r2dbc/postgresql/ConnectionContext.java
@@ -21,7 +21,7 @@ import io.r2dbc.postgresql.client.Client;
 import io.r2dbc.postgresql.codec.Codecs;
 
 /**
- * @author Mark Paluch
+ * Value object capturing contextual connection resources such as {@link Client}, {@link Codecs} and the {@link PostgresqlConnection connection facade}.
  */
 final class ConnectionContext {
 

--- a/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
+++ b/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,8 @@ package io.r2dbc.postgresql;
 
 import io.r2dbc.postgresql.api.PostgresqlStatement;
 import io.r2dbc.postgresql.client.Binding;
-import io.r2dbc.postgresql.client.Client;
 import io.r2dbc.postgresql.client.ExtendedQueryMessageFlow;
 import io.r2dbc.postgresql.client.PortalNameSupplier;
-import io.r2dbc.postgresql.codec.Codecs;
 import io.r2dbc.postgresql.message.backend.BackendMessage;
 import io.r2dbc.postgresql.message.backend.BindComplete;
 import io.r2dbc.postgresql.message.backend.CloseComplete;
@@ -48,9 +46,7 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
 
     private final Bindings bindings;
 
-    private final Client client;
-
-    private final Codecs codecs;
+    private final ConnectionContext context;
 
     private final boolean forceBinary;
 
@@ -62,9 +58,9 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
 
     private String[] generatedColumns;
 
-    ExtendedQueryPostgresqlStatement(Client client, Codecs codecs, PortalNameSupplier portalNameSupplier, String sql, StatementCache statementCache, boolean forceBinary) {
-        this.client = Assert.requireNonNull(client, "client must not be null");
-        this.codecs = Assert.requireNonNull(codecs, "codecs must not be null");
+    ExtendedQueryPostgresqlStatement(ConnectionContext context, PortalNameSupplier portalNameSupplier, String sql, StatementCache statementCache,
+                                     boolean forceBinary) {
+        this.context = Assert.requireNonNull(context, "context must not be null");
         this.portalNameSupplier = Assert.requireNonNull(portalNameSupplier, "portalNameSupplier must not be null");
         this.sql = Assert.requireNonNull(sql, "sql must not be null");
         this.statementCache = Assert.requireNonNull(statementCache, "statementCache must not be null");
@@ -91,7 +87,7 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
     public ExtendedQueryPostgresqlStatement bind(int index, Object value) {
         Assert.requireNonNull(value, "value must not be null");
 
-        this.bindings.getCurrent().add(index, this.codecs.encode(value));
+        this.bindings.getCurrent().add(index, this.context.getCodecs().encode(value));
 
         return this;
     }
@@ -110,7 +106,7 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
     public ExtendedQueryPostgresqlStatement bindNull(int index, Class<?> type) {
         Assert.requireNonNull(type, "type must not be null");
 
-        this.bindings.getCurrent().add(index, this.codecs.encodeNull(type));
+        this.bindings.getCurrent().add(index, this.context.getCodecs().encodeNull(type));
         return this;
     }
 
@@ -143,8 +139,7 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
     public String toString() {
         return "ExtendedQueryPostgresqlStatement{" +
             "bindings=" + this.bindings +
-            ", client=" + this.client +
-            ", codecs=" + this.codecs +
+            ", context=" + this.context +
             ", forceBinary=" + this.forceBinary +
             ", portalNameSupplier=" + this.portalNameSupplier +
             ", sql='" + this.sql + '\'' +
@@ -183,10 +178,10 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
         ExceptionFactory factory = ExceptionFactory.withSql(sql);
         return this.statementCache.getName(this.bindings.first(), sql)
             .flatMapMany(name -> ExtendedQueryMessageFlow
-                .execute(Flux.fromIterable(this.bindings.bindings), this.client, this.portalNameSupplier, name, sql, this.forceBinary))
+                .execute(Flux.fromIterable(this.bindings.bindings), this.context.getClient(), this.portalNameSupplier, name, sql, this.forceBinary))
             .filter(RESULT_FRAME_FILTER)
             .windowUntil(CloseComplete.class::isInstance)
-            .map(messages -> PostgresqlResult.toResult(this.codecs, messages, factory));
+            .map(messages -> PostgresqlResult.toResult(this.context, messages, factory));
     }
 
     private int getIndex(String identifier) {

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlBatch.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package io.r2dbc.postgresql;
 
-import io.r2dbc.postgresql.client.Client;
-import io.r2dbc.postgresql.codec.Codecs;
 import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.spi.Batch;
 import reactor.core.publisher.Flux;
@@ -30,15 +28,12 @@ import java.util.List;
  */
 final class PostgresqlBatch implements io.r2dbc.postgresql.api.PostgresqlBatch {
 
-    private final Client client;
-
-    private final Codecs codecs;
+    private final ConnectionContext context;
 
     private final List<String> statements = new ArrayList<>();
 
-    PostgresqlBatch(Client client, Codecs codecs) {
-        this.client = Assert.requireNonNull(client, "client must not be null");
-        this.codecs = Assert.requireNonNull(codecs, "codecs must not be null");
+    PostgresqlBatch(ConnectionContext context) {
+        this.context = Assert.requireNonNull(context, "context must not be null");
     }
 
     @Override
@@ -55,15 +50,14 @@ final class PostgresqlBatch implements io.r2dbc.postgresql.api.PostgresqlBatch {
 
     @Override
     public Flux<io.r2dbc.postgresql.api.PostgresqlResult> execute() {
-        return new SimpleQueryPostgresqlStatement(this.client, this.codecs, String.join("; ", this.statements))
+        return new SimpleQueryPostgresqlStatement(this.context, String.join("; ", this.statements))
             .execute();
     }
 
     @Override
     public String toString() {
         return "PostgresqlBatch{" +
-            "client=" + this.client +
-            ", codecs=" + this.codecs +
+            "context=" + this.context +
             ", statements=" + this.statements +
             '}';
     }

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,8 @@ final class PostgresqlConnection implements io.r2dbc.postgresql.api.PostgresqlCo
 
     private final Logger logger = Loggers.getLogger(this.getClass());
 
+    private final ConnectionContext context;
+
     private final Client client;
 
     private final Codecs codecs;
@@ -70,13 +72,14 @@ final class PostgresqlConnection implements io.r2dbc.postgresql.api.PostgresqlCo
     private volatile IsolationLevel isolationLevel;
 
     PostgresqlConnection(Client client, Codecs codecs, PortalNameSupplier portalNameSupplier, StatementCache statementCache, IsolationLevel isolationLevel, boolean forceBinary) {
+        this.context = new ConnectionContext(client, codecs, this);
         this.client = Assert.requireNonNull(client, "client must not be null");
         this.codecs = Assert.requireNonNull(codecs, "codecs must not be null");
         this.portalNameSupplier = Assert.requireNonNull(portalNameSupplier, "portalNameSupplier must not be null");
         this.statementCache = Assert.requireNonNull(statementCache, "statementCache must not be null");
         this.forceBinary = forceBinary;
         this.isolationLevel = Assert.requireNonNull(isolationLevel, "isolationLevel must not be null");
-        this.validationQuery = new SimpleQueryPostgresqlStatement(this.client, this.codecs, "SELECT 1").fetchSize(0).execute().flatMap(PostgresqlResult::getRowsUpdated);
+        this.validationQuery = new SimpleQueryPostgresqlStatement(this.context, "SELECT 1").fetchSize(0).execute().flatMap(PostgresqlResult::getRowsUpdated);
     }
 
     Client getClient() {
@@ -121,7 +124,7 @@ final class PostgresqlConnection implements io.r2dbc.postgresql.api.PostgresqlCo
 
     @Override
     public PostgresqlBatch createBatch() {
-        return new PostgresqlBatch(this.client, this.codecs);
+        return new PostgresqlBatch(this.context);
     }
 
     @Override
@@ -144,9 +147,9 @@ final class PostgresqlConnection implements io.r2dbc.postgresql.api.PostgresqlCo
         Assert.requireNonNull(sql, "sql must not be null");
 
         if (SimpleQueryPostgresqlStatement.supports(sql)) {
-            return new SimpleQueryPostgresqlStatement(this.client, this.codecs, sql);
+            return new SimpleQueryPostgresqlStatement(this.context, sql);
         } else if (ExtendedQueryPostgresqlStatement.supports(sql)) {
-            return new ExtendedQueryPostgresqlStatement(this.client, this.codecs, this.portalNameSupplier, sql, this.statementCache, this.forceBinary);
+            return new ExtendedQueryPostgresqlStatement(this.context, this.portalNameSupplier, sql, this.statementCache, this.forceBinary);
         } else {
             throw new IllegalArgumentException(String.format("Statement '%s' cannot be created. This is often due to the presence of both multiple statements and parameters at the same time.", sql));
         }

--- a/src/main/java/io/r2dbc/postgresql/api/RefCursor.java
+++ b/src/main/java/io/r2dbc/postgresql/api/RefCursor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.api;
+
+import io.r2dbc.spi.Closeable;
+import reactor.core.publisher.Mono;
+
+/**
+ * A ref cursor value object. Cursor objects can be attached to a {@link PostgresqlConnection} which allows interaction with the cursor object by {@link #fetch() fetching the cursor} and
+ * {@link #close() closing} it.
+ * Cursor objects are stateful resources. Obtaining a cursor typically keeps the cursor open on the database server. The cursor object can get invalidated if the transaction is closed. Cursor
+ * objects should be {@link #close() closed} if they are no longer required.
+ * Detached cursors that were instantiated without a connection may throw {@link UnsupportedOperationException} when attempting to fetch or close the cursor.
+ */
+public interface RefCursor extends Closeable {
+
+    /**
+     * Return the ref cursor name (portal name).
+     *
+     * @return the ref cursor name (portal name).
+     */
+    String getCursorName();
+
+    /**
+     * Fetch the contents of the cursor using {@code FETCH ALL IN}.
+     *
+     * @return the {@link PostgresqlResult} associated with the ref cursor.
+     */
+    Mono<PostgresqlResult> fetch();
+
+    /**
+     * Close the cursor.
+     *
+     * @return a {@link Mono} terminating with success the cursor was closed.
+     */
+    @Override
+    Mono<Void> close();
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/DefaultCodecs.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/DefaultCodecs.java
@@ -85,6 +85,8 @@ public final class DefaultCodecs implements Codecs, CodecRegistry {
 
             new BlobCodec(byteBufAllocator),
             new ClobCodec(byteBufAllocator),
+            RefCursorCodec.INSTANCE,
+            RefCursorNameCodec.INSTANCE,
 
             new ShortArrayCodec(byteBufAllocator),
             new StringArrayCodec(byteBufAllocator),

--- a/src/main/java/io/r2dbc/postgresql/codec/RefCursorCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/RefCursorCodec.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.postgresql.api.PostgresqlResult;
+import io.r2dbc.postgresql.api.RefCursor;
+import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.message.Format;
+import io.r2dbc.postgresql.type.PostgresqlObjectId;
+import io.r2dbc.postgresql.util.Assert;
+import io.r2dbc.postgresql.util.ByteBufUtils;
+import reactor.core.publisher.Mono;
+import reactor.util.annotation.Nullable;
+
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.REF_CURSOR;
+
+final class RefCursorCodec extends AbstractCodec<RefCursor> {
+
+    static final RefCursorCodec INSTANCE = new RefCursorCodec();
+
+    RefCursorCodec() {
+        super(RefCursor.class);
+    }
+
+    @Override
+    public Parameter encodeNull() {
+        throw new UnsupportedOperationException("RefCursor cannot be encoded");
+    }
+
+    @Override
+    boolean doCanDecode(PostgresqlObjectId type, Format format) {
+        Assert.requireNonNull(format, "format must not be null");
+        Assert.requireNonNull(type, "type must not be null");
+
+        return REF_CURSOR == type;
+    }
+
+    @Override
+    RefCursor doDecode(ByteBuf buffer, PostgresqlObjectId dataType, @Nullable Format format, @Nullable Class<? extends RefCursor> type) {
+        Assert.requireNonNull(buffer, "byteBuf must not be null");
+
+        return new SimpleRefCursor(ByteBufUtils.decode(buffer));
+    }
+
+    @Override
+    Parameter doEncode(RefCursor value) {
+        throw new UnsupportedOperationException("RefCursor cannot be encoded");
+    }
+
+    static class SimpleRefCursor implements RefCursor {
+
+        private final String portal;
+
+        SimpleRefCursor(String portal) {
+            this.portal = portal;
+        }
+
+        @Override
+        public String getCursorName() {
+            return this.portal;
+        }
+
+        @Override
+        public Mono<PostgresqlResult> fetch() {
+            throw new UnsupportedOperationException("Stateless RefCursor does not support fetch()");
+        }
+
+        @Override
+        public Mono<Void> close() {
+            throw new UnsupportedOperationException("Stateless RefCursor does not support close()");
+        }
+
+        @Override
+        public String toString() {
+            return "SimpleRefCursor{" +
+                "portal='" + this.portal + '\'' +
+                '}';
+        }
+    }
+
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/RefCursorNameCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/RefCursorNameCodec.java
@@ -17,7 +17,6 @@
 package io.r2dbc.postgresql.codec;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.r2dbc.postgresql.client.Parameter;
 import io.r2dbc.postgresql.message.Format;
 import io.r2dbc.postgresql.type.PostgresqlObjectId;
@@ -25,25 +24,19 @@ import io.r2dbc.postgresql.util.Assert;
 import io.r2dbc.postgresql.util.ByteBufUtils;
 import reactor.util.annotation.Nullable;
 
-import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.BPCHAR;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.CHAR;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.TEXT;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.UNKNOWN;
-import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.REF_CURSOR;
 
-final class StringCodec extends AbstractCodec<String> {
+final class RefCursorNameCodec extends AbstractCodec<String> {
 
-    private final ByteBufAllocator byteBufAllocator;
+    static final RefCursorNameCodec INSTANCE = new RefCursorNameCodec();
 
-    StringCodec(ByteBufAllocator byteBufAllocator) {
+    RefCursorNameCodec() {
         super(String.class);
-        this.byteBufAllocator = Assert.requireNonNull(byteBufAllocator, "byteBufAllocator must not be null");
     }
 
     @Override
     public Parameter encodeNull() {
-        return createNull(VARCHAR, FORMAT_TEXT);
+        throw new UnsupportedOperationException("Cannot encode RefCursor");
     }
 
     @Override
@@ -51,7 +44,7 @@ final class StringCodec extends AbstractCodec<String> {
         Assert.requireNonNull(format, "format must not be null");
         Assert.requireNonNull(type, "type must not be null");
 
-        return BPCHAR == type || CHAR == type || TEXT == type || UNKNOWN == type || VARCHAR == type;
+        return REF_CURSOR == type;
     }
 
     @Override
@@ -63,9 +56,7 @@ final class StringCodec extends AbstractCodec<String> {
 
     @Override
     Parameter doEncode(String value) {
-        Assert.requireNonNull(value, "value must not be null");
-
-        return create(VARCHAR, FORMAT_TEXT, () -> ByteBufUtils.encode(this.byteBufAllocator, value));
+        throw new UnsupportedOperationException("Cannot encode RefCursor");
     }
 
 }

--- a/src/test/java/io/r2dbc/postgresql/AbstractIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/AbstractIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ import reactor.test.StepVerifier;
 /**
  * Support class for integration tests using {@link PostgresqlConnection}.
  */
-abstract class AbstractIntegrationTests {
+public abstract class AbstractIntegrationTests {
 
     @RegisterExtension
-    static final PostgresqlServerExtension SERVER = new PostgresqlServerExtension();
+    public static final PostgresqlServerExtension SERVER = new PostgresqlServerExtension();
 
     PostgresqlConnectionFactory connectionFactory;
 

--- a/src/test/java/io/r2dbc/postgresql/AbstractIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/AbstractIntegrationTests.java
@@ -31,9 +31,9 @@ public abstract class AbstractIntegrationTests {
     @RegisterExtension
     public static final PostgresqlServerExtension SERVER = new PostgresqlServerExtension();
 
-    PostgresqlConnectionFactory connectionFactory;
+    public PostgresqlConnectionFactory connectionFactory;
 
-    PostgresqlConnection connection;
+    public PostgresqlConnection connection;
 
     /**
      * Entry-point to obtain a {@link PostgresqlConnectionFactory}.

--- a/src/test/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatementTest.java
+++ b/src/test/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,12 +43,10 @@ import reactor.test.StepVerifier;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 
 import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
-import static io.r2dbc.postgresql.client.TestClient.NO_OP;
 import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
 import static io.r2dbc.postgresql.type.PostgresqlObjectId.INT4;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
@@ -68,7 +66,8 @@ final class ExtendedQueryPostgresqlStatementTest {
 
     private final StatementCache statementCache = mock(StatementCache.class, RETURNS_SMART_NULLS);
 
-    private final ExtendedQueryPostgresqlStatement statement = new ExtendedQueryPostgresqlStatement(NO_OP, this.codecs, () -> "", "test-query-$1", this.statementCache, false);
+    private final ExtendedQueryPostgresqlStatement statement = new ExtendedQueryPostgresqlStatement(MockContext.builder().codecs(codecs).build(), () -> "", "test-query-$1", this.statementCache,
+        false);
 
     @Test
     void bind() {
@@ -104,7 +103,7 @@ final class ExtendedQueryPostgresqlStatementTest {
             .encoding(Integer.class, new Parameter(FORMAT_BINARY, INT4.getObjectId(), NULL_VALUE))
             .build();
 
-        ExtendedQueryPostgresqlStatement statement = new ExtendedQueryPostgresqlStatement(NO_OP, codecs, () -> "", "test-query-$1", this.statementCache, false);
+        ExtendedQueryPostgresqlStatement statement = new ExtendedQueryPostgresqlStatement(MockContext.builder().codecs(codecs).build(), () -> "", "test-query-$1", this.statementCache, false);
 
         assertThat(statement.bindNull("$1", Integer.class).getCurrentBinding())
             .isEqualTo(new Binding(1).add(0, new Parameter(FORMAT_BINARY, INT4.getObjectId(), NULL_VALUE)));
@@ -141,32 +140,26 @@ final class ExtendedQueryPostgresqlStatementTest {
     }
 
     @Test
-    void constructorNoClient() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(null, MockCodecs.empty(), () -> "", "test-query", this.statementCache, false))
-            .withMessage("client must not be null");
-    }
-
-    @Test
-    void constructorNoCodecs() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(NO_OP, null, () -> "", "test-query", this.statementCache, false))
-            .withMessage("codecs must not be null");
+    void constructorNoContext() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(null, () -> "", "test-query", this.statementCache, false))
+            .withMessage("context must not be null");
     }
 
     @Test
     void constructorNoPortalNameSupplier() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), null, "test-query", this.statementCache, false))
+        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(MockContext.empty(), null, "test-query", this.statementCache, false))
             .withMessage("portalNameSupplier must not be null");
     }
 
     @Test
     void constructorNoSql() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), () -> "", null, this.statementCache, false))
+        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(MockContext.empty(), () -> "", null, this.statementCache, false))
             .withMessage("sql must not be null");
     }
 
     @Test
     void constructorNoStatementCache() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), () -> "", "test-query", null, false))
+        assertThatIllegalArgumentException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(MockContext.empty(), () -> "", "test-query", null, false))
             .withMessage("statementCache must not be null");
     }
 
@@ -198,7 +191,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(MockContext.builder().client(client).codecs(codecs).build(), portalNameSupplier, "test-query-$1-$1", this.statementCache, false)
             .bind("$1", 100)
             .add()
             .bind("$1", 200)
@@ -235,7 +228,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(MockContext.builder().client(client).codecs(codecs).build(), portalNameSupplier, "test-query-$1", this.statementCache, false)
             .bind("$1", 100)
             .execute()
             .flatMap(PostgresqlResult::getRowsUpdated)
@@ -263,7 +256,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(MockContext.builder().client(client).codecs(codecs).build(), portalNameSupplier, "test-query-$1", this.statementCache, false)
             .bind("$1", 100)
             .execute()
             .flatMap(result -> result.map((row, rowMetadata) -> row))
@@ -291,7 +284,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(MockContext.builder().client(client).codecs(codecs).build(), portalNameSupplier, "test-query-$1", this.statementCache, false)
             .bind("$1", 100)
             .execute()
             .flatMap(PostgresqlResult::getRowsUpdated)
@@ -319,7 +312,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(MockContext.builder().client(client).codecs(codecs).build(), portalNameSupplier, "test-query-$1", this.statementCache, false)
             .bind("$1", 100)
             .execute()
             .flatMap(PostgresqlResult::getRowsUpdated)
@@ -348,7 +341,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(MockContext.builder().client(client).codecs(codecs).build(), portalNameSupplier, "test-query-$1", this.statementCache, false)
             .bind("$1", 100)
             .execute()
             .as(StepVerifier::create)
@@ -377,7 +370,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "test-query-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(MockContext.builder().client(client).codecs(codecs).build(), portalNameSupplier, "test-query-$1", this.statementCache, false)
             .bind("$1", 100)
             .execute()
             .flatMap(result -> result.map((row, metadata) -> 1))
@@ -408,7 +401,7 @@ final class ExtendedQueryPostgresqlStatementTest {
 
         when(this.statementCache.getName(any(), any())).thenReturn(Mono.just("test-name"));
 
-        new ExtendedQueryPostgresqlStatement(client, codecs, portalNameSupplier, "INSERT test-query-$1", this.statementCache, false)
+        new ExtendedQueryPostgresqlStatement(MockContext.builder().client(client).codecs(codecs).build(), portalNameSupplier, "INSERT test-query-$1", this.statementCache, false)
             .bind("$1", 100)
             .returnGeneratedValues()
             .execute()
@@ -420,13 +413,13 @@ final class ExtendedQueryPostgresqlStatementTest {
 
     @Test
     void returnGeneratedValuesHasReturningClause() {
-        assertThatIllegalStateException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), () -> "", "RETURNING", this.statementCache, false).returnGeneratedValues())
+        assertThatIllegalStateException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(MockContext.empty(), () -> "", "RETURNING", this.statementCache, false).returnGeneratedValues())
             .withMessage("Statement already includes RETURNING clause");
     }
 
     @Test
     void returnGeneratedValuesUnsupportedCommand() {
-        assertThatIllegalStateException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), () -> "", "SELECT", this.statementCache, false).returnGeneratedValues())
+        assertThatIllegalStateException().isThrownBy(() -> new ExtendedQueryPostgresqlStatement(MockContext.empty(), () -> "", "SELECT", this.statementCache, false).returnGeneratedValues())
             .withMessage("Statement is not a DELETE, INSERT, or UPDATE command");
     }
 

--- a/src/test/java/io/r2dbc/postgresql/MockContext.java
+++ b/src/test/java/io/r2dbc/postgresql/MockContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql;
+
+import io.r2dbc.postgresql.api.PostgresqlConnection;
+import io.r2dbc.postgresql.client.Client;
+import io.r2dbc.postgresql.codec.Codecs;
+import io.r2dbc.postgresql.codec.MockCodecs;
+
+final class MockContext {
+
+    public static MockContext.Builder builder() {
+        return new MockContext.Builder();
+    }
+
+    public static ConnectionContext empty() {
+        return builder().build();
+    }
+
+    public static final class Builder {
+
+        private Codecs codecs = MockCodecs.empty();
+
+        private Client client;
+
+        private PostgresqlConnection connection;
+
+
+        private Builder() {
+        }
+
+        public ConnectionContext build() {
+            return new ConnectionContext(this.client, this.codecs, this.connection);
+        }
+
+        public Builder codecs(Codecs codecs) {
+            this.codecs = codecs;
+            return this;
+        }
+
+        public Builder client(Client client) {
+            this.client = client;
+            return this;
+        }
+
+        public Builder connection(PostgresqlConnection connection) {
+            this.connection = connection;
+            return this;
+        }
+
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlResultTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package io.r2dbc.postgresql;
 
-import io.r2dbc.postgresql.codec.MockCodecs;
 import io.r2dbc.postgresql.message.backend.CommandComplete;
 import io.r2dbc.postgresql.message.backend.DataRow;
 import io.r2dbc.postgresql.message.backend.EmptyQueryResponse;
@@ -32,20 +31,14 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 final class PostgresqlResultTest {
 
     @Test
-    void constructorNoCodec() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlResult(null, Flux.empty(), ExceptionFactory.INSTANCE))
-            .withMessage("codecs must not be null");
-    }
-
-    @Test
     void constructorNoRowMetadata() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlResult(MockCodecs.empty(), null, ExceptionFactory.INSTANCE))
+        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlResult(MockContext.empty(), null, ExceptionFactory.INSTANCE))
             .withMessage("messages must not be null");
     }
 
     @Test
     void toResultCommandComplete() {
-        PostgresqlResult result = PostgresqlResult.toResult(MockCodecs.empty(), Flux.just(new CommandComplete("test", null, 1)), ExceptionFactory.INSTANCE);
+        PostgresqlResult result = PostgresqlResult.toResult(MockContext.empty(), Flux.just(new CommandComplete("test", null, 1)), ExceptionFactory.INSTANCE);
 
         result.map((row, rowMetadata) -> row)
             .as(StepVerifier::create)
@@ -59,7 +52,7 @@ final class PostgresqlResultTest {
 
     @Test
     void toResultEmptyQueryResponse() {
-        PostgresqlResult result = PostgresqlResult.toResult(MockCodecs.empty(), Flux.just(EmptyQueryResponse.INSTANCE), ExceptionFactory.INSTANCE);
+        PostgresqlResult result = PostgresqlResult.toResult(MockContext.empty(), Flux.just(EmptyQueryResponse.INSTANCE), ExceptionFactory.INSTANCE);
 
         result.map((row, rowMetadata) -> row)
             .as(StepVerifier::create)
@@ -71,20 +64,20 @@ final class PostgresqlResultTest {
     }
 
     @Test
-    void toResultNoCodecs() {
+    void toResultNoContext() {
         assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlResult.toResult(null, Flux.empty(), ExceptionFactory.INSTANCE))
-            .withMessage("codecs must not be null");
+            .withMessage("context must not be null");
     }
 
     @Test
     void toResultNoMessages() {
-        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlResult.toResult(MockCodecs.empty(), null, ExceptionFactory.INSTANCE))
+        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlResult.toResult(MockContext.empty(), null, ExceptionFactory.INSTANCE))
             .withMessage("messages must not be null");
     }
 
     @Test
     void toResultRowDescriptionRowsUpdated() {
-        PostgresqlResult result = PostgresqlResult.toResult(MockCodecs.empty(), Flux.just(new RowDescription(Collections.emptyList()), new DataRow(), new CommandComplete
+        PostgresqlResult result = PostgresqlResult.toResult(MockContext.empty(), Flux.just(new RowDescription(Collections.emptyList()), new DataRow(), new CommandComplete
             ("test", null, null)), ExceptionFactory.INSTANCE);
 
         result.getRowsUpdated()
@@ -94,7 +87,7 @@ final class PostgresqlResultTest {
 
     @Test
     void toResultRowDescriptionMap() {
-        PostgresqlResult result = PostgresqlResult.toResult(MockCodecs.empty(), Flux.just(new RowDescription(Collections.emptyList()), new DataRow(), new CommandComplete
+        PostgresqlResult result = PostgresqlResult.toResult(MockContext.empty(), Flux.just(new RowDescription(Collections.emptyList()), new DataRow(), new CommandComplete
             ("test", null, null)), ExceptionFactory.INSTANCE);
 
         result.map((row, rowMetadata) -> row)

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlRowTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlRowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,14 +44,14 @@ final class PostgresqlRowTest {
     private final ByteBuf[] data = new ByteBuf[]{TEST.buffer(4).writeInt(100), TEST.buffer(4).writeInt(300), null};
 
     @Test
-    void constructorNoCodecs() {
+    void constructorNoContext() {
         assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(null, Collections.emptyList(), null))
-            .withMessage("codecs must not be null");
+            .withMessage("context must not be null");
     }
 
     @Test
     void constructorNoColumns() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockCodecs.empty(), null, null))
+        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockContext.empty(), null, null))
             .withMessage("fields must not be null");
     }
 
@@ -63,7 +63,7 @@ final class PostgresqlRowTest {
             .decoding(TEST.buffer(4).writeInt(300), 400, FORMAT_TEXT, Object.class, value)
             .build();
 
-        PostgresqlRow row = new PostgresqlRow(codecs, this.columns, new ByteBuf[0]);
+        PostgresqlRow row = new PostgresqlRow(MockContext.builder().codecs(codecs).build(), this.columns, new ByteBuf[0]);
         row.release();
 
         assertThatIllegalStateException().isThrownBy(() -> row.get("test-name-2", Object.class))
@@ -78,7 +78,7 @@ final class PostgresqlRowTest {
             .decoding(TEST.buffer(4).writeInt(300), 400, FORMAT_TEXT, Object.class, value)
             .build();
 
-        assertThat(new PostgresqlRow(codecs, this.columns, this.data).get("test-name-2")).isSameAs(value);
+        assertThat(new PostgresqlRow(MockContext.builder().codecs(codecs).build(), this.columns, this.data).get("test-name-2")).isSameAs(value);
     }
 
     @Test
@@ -89,18 +89,18 @@ final class PostgresqlRowTest {
             .decoding(TEST.buffer(4).writeInt(300), 400, FORMAT_TEXT, Object.class, value)
             .build();
 
-        assertThat(new PostgresqlRow(codecs, this.columns, this.data).get(1, Object.class)).isSameAs(value);
+        assertThat(new PostgresqlRow(MockContext.builder().codecs(codecs).build(), this.columns, this.data).get(1, Object.class)).isSameAs(value);
     }
 
     @Test
     void getInvalidIndex() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockCodecs.empty(), this.columns, new ByteBuf[0]).get(3, Object.class))
+        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockContext.empty(), this.columns, new ByteBuf[0]).get(3, Object.class))
             .withMessage("Column index 3 is larger than the number of columns 3");
     }
 
     @Test
     void getInvalidName() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockCodecs.empty(), this.columns, new ByteBuf[0]).get("test-name-4", Object.class))
+        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockContext.empty(), this.columns, new ByteBuf[0]).get("test-name-4", Object.class))
             .withMessageMatching("Column name 'test-name-4' does not exist in column names \\[test-name-[\\d], test-name-[\\d], test-name-[\\d]\\]");
     }
 
@@ -112,18 +112,18 @@ final class PostgresqlRowTest {
             .decoding(TEST.buffer(4).writeInt(300), 400, FORMAT_TEXT, Object.class, value)
             .build();
 
-        assertThat(new PostgresqlRow(codecs, this.columns, this.data).get("test-name-2", Object.class)).isSameAs(value);
+        assertThat(new PostgresqlRow(MockContext.builder().codecs(codecs).build(), this.columns, this.data).get("test-name-2", Object.class)).isSameAs(value);
     }
 
     @Test
     void getNoIdentifier() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockCodecs.empty(), this.columns, new ByteBuf[0]).get(null, Object.class))
+        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockContext.empty(), this.columns, new ByteBuf[0]).get(null, Object.class))
             .withMessage("name must not be null");
     }
 
     @Test
     void getNoType() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockCodecs.empty(), this.columns, new ByteBuf[0]).get("", null))
+        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlRow(MockContext.empty(), this.columns, new ByteBuf[0]).get("", null))
             .withMessage("type must not be null");
     }
 
@@ -133,7 +133,7 @@ final class PostgresqlRowTest {
             .decoding(null, 400, FORMAT_TEXT, Object.class, null)
             .build();
 
-        assertThat(new PostgresqlRow(codecs, this.columns, this.data).get("test-name-3", Object.class)).isNull();
+        assertThat(new PostgresqlRow(MockContext.builder().codecs(codecs).build(), this.columns, this.data).get("test-name-3", Object.class)).isNull();
     }
 
     @Test
@@ -144,28 +144,21 @@ final class PostgresqlRowTest {
             .decoding(TEST.buffer(4).writeInt(100), 300, FORMAT_TEXT, Object.class, value)
             .build();
 
-        PostgresqlRow row = PostgresqlRow.toRow(codecs, new DataRow(TEST.buffer(4).writeInt(100)),
+        PostgresqlRow row = PostgresqlRow.toRow(MockContext.builder().codecs(codecs).build(), new DataRow(TEST.buffer(4).writeInt(100)),
             new RowDescription(Collections.singletonList(new RowDescription.Field((short) 200, 300, (short) 400, (short) 500, FORMAT_TEXT, "test-name-1", 600))));
 
         assertThat(row.get(0, Object.class)).isSameAs(value);
     }
 
     @Test
-    void toRowNoCodecs() {
-        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlRow.toRow(null, new DataRow(TEST.buffer(4).writeInt(100)),
-            new RowDescription(Collections.emptyList())))
-            .withMessage("codecs must not be null");
-    }
-
-    @Test
     void toRowNoDataRow() {
-        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlRow.toRow(MockCodecs.empty(), null, new RowDescription(Collections.emptyList())))
+        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlRow.toRow(MockContext.empty(), null, new RowDescription(Collections.emptyList())))
             .withMessage("dataRow must not be null");
     }
 
     @Test
     void toRowNoRowDescription() {
-        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlRow.toRow(MockCodecs.empty(), new DataRow(TEST.buffer(4).writeInt(100)), null))
+        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlRow.toRow(MockContext.empty(), new DataRow(TEST.buffer(4).writeInt(100)), null))
             .withMessage("rowDescription must not be null");
     }
 

--- a/src/test/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatementTest.java
+++ b/src/test/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import reactor.test.StepVerifier;
 
 import java.util.Collections;
 
-import static io.r2dbc.postgresql.client.TestClient.NO_OP;
 import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
 import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,45 +44,39 @@ final class SimpleQueryPostgresqlStatementTest {
 
     @Test
     void bind() {
-        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> new SimpleQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), "test-query").bind(null, null))
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> new SimpleQueryPostgresqlStatement(MockContext.empty(), "test-query").bind(null, null))
             .withMessage("Binding parameters is not supported for the statement 'test-query'");
     }
 
     @Test
     void bindIndex() {
-        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> new SimpleQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), "test-query").bind(0, null))
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> new SimpleQueryPostgresqlStatement(MockContext.empty(), "test-query").bind(0, null))
             .withMessage("Binding parameters is not supported for the statement 'test-query'");
     }
 
 
     @Test
     void bindNull() {
-        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> new SimpleQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), "test-query").bindNull(null, null))
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> new SimpleQueryPostgresqlStatement(MockContext.empty(), "test-query").bindNull(null, null))
             .withMessage("Binding parameters is not supported for the statement 'test-query'");
     }
 
     @Test
     void bindNullIndex() {
-        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> new SimpleQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), "test-query").bindNull(0, null))
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> new SimpleQueryPostgresqlStatement(MockContext.empty(), "test-query").bindNull(0, null))
             .withMessage("Binding parameters is not supported for the statement 'test-query'");
     }
 
 
     @Test
-    void constructorNoClient() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(null, MockCodecs.empty(), "test-query"))
-            .withMessage("client must not be null");
-    }
-
-    @Test
-    void constructorNoCodecs() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(NO_OP, null, "test-query"))
-            .withMessage("codecs must not be null");
+    void constructorNoContext() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(null, "test-query"))
+            .withMessage("context must not be null");
     }
 
     @Test
     void constructorNoSql() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), null))
+        assertThatIllegalArgumentException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(MockContext.empty(), null))
             .withMessage("sql must not be null");
     }
 
@@ -93,7 +86,7 @@ final class SimpleQueryPostgresqlStatementTest {
             .expectRequest(new Query("test-query")).thenRespond(new CommandComplete("test", null, 1))
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "test-query")
             .execute()
             .flatMap(result -> result.map((row, rowMetadata) -> row))
             .as(StepVerifier::create)
@@ -106,7 +99,7 @@ final class SimpleQueryPostgresqlStatementTest {
             .expectRequest(new Query("test-query")).thenRespond(new CommandComplete("test", null, 1))
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "test-query")
             .execute()
             .flatMap(PostgresqlResult::getRowsUpdated)
             .as(StepVerifier::create)
@@ -120,7 +113,7 @@ final class SimpleQueryPostgresqlStatementTest {
             .expectRequest(new Query("test-query")).thenRespond(EmptyQueryResponse.INSTANCE)
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "test-query")
             .execute()
             .flatMap(result -> result.map((row, rowMetadata) -> row))
             .as(StepVerifier::create)
@@ -133,7 +126,7 @@ final class SimpleQueryPostgresqlStatementTest {
             .expectRequest(new Query("test-query")).thenRespond(EmptyQueryResponse.INSTANCE)
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "test-query")
             .execute()
             .flatMap(PostgresqlResult::getRowsUpdated)
             .as(StepVerifier::create)
@@ -146,7 +139,7 @@ final class SimpleQueryPostgresqlStatementTest {
             .expectRequest(new Query("test-query")).thenRespond(new ErrorResponse(Collections.emptyList()))
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "test-query")
             .execute()
             .flatMap(result -> result.map((row, rowMetadata) -> row))
             .as(StepVerifier::create)
@@ -159,7 +152,7 @@ final class SimpleQueryPostgresqlStatementTest {
             .expectRequest(new Query("test-query")).thenRespond(new ErrorResponse(Collections.emptyList()))
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "test-query")
             .execute()
             .flatMap(PostgresqlResult::getRowsUpdated)
             .as(StepVerifier::create)
@@ -172,7 +165,7 @@ final class SimpleQueryPostgresqlStatementTest {
             .expectRequest(new Query("test-query")).thenRespond(new ErrorResponse(Collections.emptyList()))
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "test-query")
             .execute()
             .flatMap(PostgresqlResult::getRowsUpdated)
             .as(StepVerifier::create)
@@ -194,11 +187,13 @@ final class SimpleQueryPostgresqlStatementTest {
             .preferredType(200, FORMAT_TEXT, String.class)
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, codecs, "test-query")
+        ConnectionContext context = MockContext.builder().client(client).codecs(codecs).build();
+
+        new SimpleQueryPostgresqlStatement(context, "test-query")
             .execute()
             .flatMap(result -> result.map((row, rowMetadata) -> row))
             .as(StepVerifier::create)
-            .expectNext(new PostgresqlRow(MockCodecs.empty(), Collections.singletonList(field),
+            .expectNext(new PostgresqlRow(context, Collections.singletonList(field),
                 new ByteBuf[]{TEST.buffer(4).writeInt(100)}))
             .verifyComplete();
     }
@@ -213,7 +208,7 @@ final class SimpleQueryPostgresqlStatementTest {
                 new CommandComplete("test", null, null))
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "test-query")
             .execute()
             .flatMap(PostgresqlResult::getRowsUpdated)
             .as(StepVerifier::create)
@@ -226,7 +221,7 @@ final class SimpleQueryPostgresqlStatementTest {
             .expectRequest(new Query("INSERT test-query RETURNING *")).thenRespond(new CommandComplete("test", null, 1))
             .build();
 
-        new SimpleQueryPostgresqlStatement(client, MockCodecs.empty(), "INSERT test-query")
+        new SimpleQueryPostgresqlStatement(MockContext.builder().client(client).build(), "INSERT test-query")
             .returnGeneratedValues()
             .execute()
             .flatMap(result -> result.map((row, rowMetadata) -> row))
@@ -236,13 +231,13 @@ final class SimpleQueryPostgresqlStatementTest {
 
     @Test
     void returnGeneratedValuesHasReturningClause() {
-        assertThatIllegalStateException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), "RETURNING").returnGeneratedValues())
+        assertThatIllegalStateException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(MockContext.empty(), "RETURNING").returnGeneratedValues())
             .withMessage("Statement already includes RETURNING clause");
     }
 
     @Test
     void returnGeneratedValuesUnsupportedCommand() {
-        assertThatIllegalStateException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(NO_OP, MockCodecs.empty(), "SELECT").returnGeneratedValues())
+        assertThatIllegalStateException().isThrownBy(() -> new SimpleQueryPostgresqlStatement(MockContext.empty(), "SELECT").returnGeneratedValues())
             .withMessage("Statement is not a DELETE, INSERT, or UPDATE command");
     }
 

--- a/src/test/java/io/r2dbc/postgresql/codec/RefCursorCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/RefCursorCodecTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.r2dbc.postgresql.api.RefCursor;
+import org.junit.jupiter.api.Test;
+
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.MONEY;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.REF_CURSOR;
+import static io.r2dbc.postgresql.util.ByteBufUtils.encode;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+final class RefCursorCodecTest {
+
+    private static final int dataType = REF_CURSOR.getObjectId();
+
+    @Test
+    void decode() {
+        RefCursor refCursor = new RefCursorCodec().decode(encode(TEST, "test"), dataType, FORMAT_TEXT, RefCursor.class);
+        assertThat(refCursor.getCursorName())
+            .isEqualTo("test");
+    }
+
+    @Test
+    void detachedRefCursorDoesNotSupportFetching() {
+        RefCursor refCursor = new RefCursorCodec().decode(encode(TEST, "test"), dataType, FORMAT_TEXT, RefCursor.class);
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(refCursor::fetch);
+    }
+
+    @Test
+    void detachedRefCursorDoesNotSupportClosing() {
+        RefCursor refCursor = new RefCursorCodec().decode(encode(TEST, "test"), dataType, FORMAT_TEXT, RefCursor.class);
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(refCursor::close);
+    }
+
+    @Test
+    void decodeNoByteBuf() {
+        assertThat(new RefCursorCodec().decode(null, dataType, FORMAT_TEXT, RefCursor.class)).isNull();
+    }
+
+    @Test
+    void doCanDecode() {
+        RefCursorCodec codec = RefCursorCodec.INSTANCE;
+
+        assertThat(codec.doCanDecode(REF_CURSOR, FORMAT_BINARY)).isTrue();
+        assertThat(codec.doCanDecode(MONEY, FORMAT_TEXT)).isFalse();
+    }
+
+}

--- a/src/test/java/io/r2dbc/postgresql/feature/RefCursorIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/feature/RefCursorIntegrationTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.feature;
+
+import io.r2dbc.postgresql.AbstractIntegrationTests;
+import io.r2dbc.postgresql.api.PostgresqlResult;
+import io.r2dbc.postgresql.api.RefCursor;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.postgresql.jdbc.PgResultSet;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class RefCursorIntegrationTests extends AbstractIntegrationTests {
+
+    @BeforeEach
+    void prepare() {
+
+        SERVER.getJdbcOperations().execute("CREATE TABLE IF NOT EXISTS cities (city VARCHAR(255), state VARCHAR(2))");
+        SERVER.getJdbcOperations().execute("DELETE FROM cities");
+
+        SERVER.getJdbcOperations().execute("CREATE OR REPLACE FUNCTION show_cities() RETURNS refcursor AS $$\n" +
+            "    DECLARE\n" +
+            "      ref refcursor;                                                     -- Declare a cursor variable\n" +
+            "    BEGIN\n" +
+            "      OPEN ref FOR SELECT city, state FROM cities;   -- Open a cursor\n" +
+            "      RETURN ref;                                                       -- Return the cursor to the caller\n" +
+            "    END;\n" +
+            "    $$ LANGUAGE plpgsql;");
+
+
+        SERVER.getJdbcOperations().execute("CREATE OR REPLACE FUNCTION show_cities_multiple() RETURNS SETOF refcursor AS $$\n" +
+            "    DECLARE\n" +
+            "      ref1 refcursor;           -- Declare cursor variables\n" +
+            "      ref2 refcursor;                             \n" +
+            "    BEGIN\n" +
+            "      OPEN ref1 FOR SELECT city, state FROM cities WHERE state = 'BW';   -- Open the first cursor\n" +
+            "      RETURN NEXT ref1;                                                                              -- Return the cursor to the caller\n" +
+            " \n" +
+            "      OPEN ref2 FOR SELECT city, state FROM cities WHERE state = 'HE';   -- Open the second cursor\n" +
+            "      RETURN NEXT ref2;                                                                              -- Return the cursor to the caller\n" +
+            "    END;\n" +
+            "    $$ LANGUAGE plpgsql;");
+
+        SERVER.getJdbcOperations().execute("INSERT INTO cities VALUES('Weinheim', 'BW')");
+        SERVER.getJdbcOperations().execute("INSERT INTO cities VALUES('Frankfurt', 'HE')");
+
+        connection.setAutoCommit(false).as(StepVerifier::create).verifyComplete();
+    }
+
+    @Test
+    void fetchCursorWithoutTxShouldFail() {
+
+        connection.setAutoCommit(true).as(StepVerifier::create).verifyComplete();
+
+        connection.createStatement("SELECT show_cities()").execute()
+            .flatMap(result -> result.map((row, rowMetadata) -> row.get(0, RefCursor.class)))
+            .flatMap(RefCursor::fetch)
+            .flatMap(PostgresqlResult::getRowsUpdated)
+            .as(StepVerifier::create)
+            .verifyError(R2dbcNonTransientResourceException.class);
+    }
+
+    @Test
+    void shouldReturnSingleRefCursorFromJdbc() {
+
+        DataSourceTransactionManager tm = new DataSourceTransactionManager(SERVER.getDataSource());
+
+        TransactionTemplate tt = new TransactionTemplate(tm);
+
+        Map<String, Object> object = tt.execute(transactionStatus -> {
+            return SERVER.getJdbcOperations().queryForMap("SELECT show_cities()");
+        });
+
+        assertThat(object).containsKey("show_cities");
+        assertThat(object.get("show_cities")).isInstanceOf(PgResultSet.class);
+
+        PgResultSet rs = (PgResultSet) object.get("show_cities");
+        assertThat(rs.getRefCursor()).isNotEmpty();
+    }
+
+    @Test
+    void shouldReturnSingleRefCursor() {
+
+        List<String> results = new ArrayList<>();
+
+        connection.createStatement("SELECT show_cities()").execute()
+            .flatMap(result -> result.map((row, rowMetadata) -> row.get(0, RefCursor.class)))
+            .flatMap(rc -> rc.fetch().flatMapMany(it -> it.map((row, rowMetadata) -> row.get(0, String.class)))
+                .doOnNext(results::add)
+                .then(rc.close()))
+            .as(StepVerifier::create)
+            .verifyComplete();
+
+        assertThat(results).contains("Weinheim", "Frankfurt");
+    }
+
+    @Test
+    void shouldReturnRefCursor() {
+
+        connection.createStatement("SELECT show_cities()").execute()
+            .flatMap(result -> result.map((row, rowMetadata) -> row.get(0)))
+            .as(StepVerifier::create)
+            .consumeNextWith(actual -> assertThat(actual).isInstanceOf(RefCursor.class))
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnCursorNameAsString() {
+
+        connection.createStatement("SELECT show_cities()").execute()
+            .flatMap(result -> result.map((row, rowMetadata) -> row.get(0, String.class)))
+            .as(StepVerifier::create)
+            .expectNextCount(1)
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnMultipleRefCursorFromJdbc() {
+
+        DataSourceTransactionManager tm = new DataSourceTransactionManager(SERVER.getDataSource());
+
+        TransactionTemplate tt = new TransactionTemplate(tm);
+
+        List<Map<String, Object>> cursors = tt.execute(transactionStatus -> {
+            return SERVER.getJdbcOperations().queryForList("SELECT show_cities_multiple()");
+        });
+
+        assertThat(cursors).hasSize(2);
+    }
+
+    @Test
+    void shouldReturnMultipleRefCursor() {
+
+        List<String> results = new ArrayList<>();
+        List<String> cursorNames = new ArrayList<>();
+
+        connection.createStatement("SELECT show_cities_multiple()").execute()
+            .flatMap(result -> result.map((row, rowMetadata) -> row.get(0, RefCursor.class)))
+            .flatMap(rc -> {
+                cursorNames.add(rc.getCursorName());
+                return rc.fetch().flatMapMany(it -> it.map((row, rowMetadata) -> row.get(0, String.class)))
+                    .doOnNext(results::add)
+                    .then(rc.close());
+            })
+            .as(StepVerifier::create)
+            .verifyComplete();
+
+        assertThat(results).contains("Weinheim", "Frankfurt");
+        assertThat(cursorNames).hasSize(2);
+    }
+
+}


### PR DESCRIPTION
We now can decode a `RefCursor` from a `Row` and fetch the data that the cursor holds.

```java
RefCursor cursor = row.get("my_store_procedure", RefCursor.class);

// later
cursor.fetch().then(cursor.close());
```

[closes #173]

/cc @Squiry @davecramer 