### PR TITLE
Add default fetch size support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | `database`        | Database to select. _(Optional)_
 | `applicationName` | The name of the application connecting to the database.  Defaults to `r2dbc-postgresql`. _(Optional)_
 | `autodetectExtensions` | Whether to auto-detect and register `Extension`s from the class path.  Defaults to `true`. _(Optional)_
+| `fetchSize`       | The default number of rows to return when fetching results. Defaults to `0` for unlimited. _(Optional)_
 | `forceBinary`     | Whether to force binary transfer.  Defaults to `false`. _(Optional)_
 | `preparedStatementCacheQueries` | Determine the number of queries that are cached in each connection. The default is `-1`, meaning there's no limit. The value of `0` disables the cache. Any other value specifies the cache size.
 | `options`         | A `Map<String, String>` of connection parameters. These are applied to each database connection created by the `ConnectionFactory`. Useful for setting generic [PostgreSQL connection parameters][psql-runtime-config]. _(Optional)_

--- a/src/main/java/io/r2dbc/postgresql/ConnectionContext.java
+++ b/src/main/java/io/r2dbc/postgresql/ConnectionContext.java
@@ -33,17 +33,17 @@ final class ConnectionContext {
 
     private final PostgresqlConnection connection;
 
-    private final boolean forceBinary;
+    private final PostgresqlConnectionConfiguration configuration;
 
     private final StatementCache statementCache;
 
     private final PortalNameSupplier portalNameSupplier;
 
-    ConnectionContext(Client client, Codecs codecs, PostgresqlConnection connection, boolean forceBinary, PortalNameSupplier portalNameSupplier, StatementCache statementCache) {
+    ConnectionContext(Client client, Codecs codecs, PostgresqlConnection connection, PostgresqlConnectionConfiguration configuration, PortalNameSupplier portalNameSupplier, StatementCache statementCache) {
         this.client = client;
         this.codecs = codecs;
         this.connection = connection;
-        this.forceBinary = forceBinary;
+        this.configuration = configuration;
         this.portalNameSupplier = Assert.requireNonNull(portalNameSupplier, "portalNameSupplier must not be null");
         this.statementCache = Assert.requireNonNull(statementCache, "statementCache must not be null");
     }
@@ -60,8 +60,8 @@ final class ConnectionContext {
         return this.connection;
     }
 
-    public boolean isForceBinary() {
-        return this.forceBinary;
+    public PostgresqlConnectionConfiguration getConfiguration() {
+        return this.configuration;
     }
 
     public PortalNameSupplier getPortalNameSupplier() {
@@ -78,7 +78,7 @@ final class ConnectionContext {
             "client=" + this.client +
             ", codecs=" + this.codecs +
             ", connection=" + this.connection +
-            ", forceBinary=" + this.forceBinary +
+            ", configuration=" + this.configuration +
             ", portalNameSupplier=" + this.portalNameSupplier +
             ", statementCache=" + this.statementCache +
             '}';

--- a/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
+++ b/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
@@ -61,6 +61,7 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
         this.context = Assert.requireNonNull(context, "context must not be null");
         this.sql = Assert.requireNonNull(sql, "sql must not be null");
         this.bindings = new Bindings(expectedSize(sql));
+        fetchSize(this.context.getConfiguration().getFetchSize());
     }
 
     @Override
@@ -183,7 +184,7 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
 
     static PostgresqlResult createPostgresqlResult(String sql, ExceptionFactory factory, String statementName, Binding binding, ConnectionContext context, int fetchSize) {
         Flux<BackendMessage> messages = ExtendedQueryMessageFlow
-            .execute(binding, context.getClient(), context.getPortalNameSupplier(), statementName, sql, context.isForceBinary(), fetchSize)
+            .execute(binding, context.getClient(), context.getPortalNameSupplier(), statementName, sql, context.getConfiguration().isForceBinary(), fetchSize)
             .filter(RESULT_FRAME_FILTER);
         return PostgresqlResult.toResult(context, messages, factory);
     }

--- a/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
+++ b/src/main/java/io/r2dbc/postgresql/ExtendedQueryPostgresqlStatement.java
@@ -61,7 +61,7 @@ final class ExtendedQueryPostgresqlStatement implements PostgresqlStatement {
         this.context = Assert.requireNonNull(context, "context must not be null");
         this.sql = Assert.requireNonNull(sql, "sql must not be null");
         this.bindings = new Bindings(expectedSize(sql));
-        fetchSize(this.context.getConfiguration().getFetchSize());
+        fetchSize(this.context.getConfiguration().getFetchSize(sql));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java
@@ -68,8 +68,8 @@ final class PostgresqlConnection implements io.r2dbc.postgresql.api.PostgresqlCo
 
     private volatile IsolationLevel isolationLevel;
 
-    PostgresqlConnection(Client client, Codecs codecs, PortalNameSupplier portalNameSupplier, StatementCache statementCache, IsolationLevel isolationLevel, boolean forceBinary) {
-        this.context = new ConnectionContext(client, codecs, this, forceBinary, portalNameSupplier, statementCache);
+    PostgresqlConnection(Client client, Codecs codecs, PortalNameSupplier portalNameSupplier, StatementCache statementCache, IsolationLevel isolationLevel, PostgresqlConnectionConfiguration configuration) {
+        this.context = new ConnectionContext(client, codecs, this, configuration, portalNameSupplier, statementCache);
         this.client = Assert.requireNonNull(client, "client must not be null");
         this.codecs = Assert.requireNonNull(codecs, "codecs must not be null");
         this.isolationLevel = Assert.requireNonNull(isolationLevel, "isolationLevel must not be null");

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionConfiguration.java
@@ -25,7 +25,6 @@ import io.r2dbc.postgresql.codec.Codec;
 import io.r2dbc.postgresql.extension.CodecRegistrar;
 import io.r2dbc.postgresql.extension.Extension;
 import io.r2dbc.postgresql.util.Assert;
-import io.r2dbc.spi.Statement;
 import reactor.netty.tcp.SslProvider;
 import reactor.util.annotation.Nullable;
 
@@ -414,6 +413,7 @@ public final class PostgresqlConnectionConfiguration {
          * @return this {@code Builder}
          */
         public Builder fetchSize(int fetchSize) {
+            Assert.isTrue(fetchSize >= 0, "fetch size must be greater or equal zero");
             this.fetchSize = fetchSize;
             return this;
         }

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
@@ -168,7 +168,7 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
 
                 // early connection object to retrieve initialization details
                 PostgresqlConnection earlyConnection = new PostgresqlConnection(client, codecs, DefaultPortalNameSupplier.INSTANCE, statementCache, IsolationLevel.READ_COMMITTED,
-                    this.configuration.isForceBinary());
+                    this.configuration);
 
                 Mono<IsolationLevel> isolationLevelMono = Mono.just(IsolationLevel.READ_COMMITTED);
                 if (!forReplication) {
@@ -176,7 +176,7 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
                 }
                 return isolationLevelMono
                     // actual connection to be used
-                    .map(isolationLevel -> new PostgresqlConnection(client, codecs, DefaultPortalNameSupplier.INSTANCE, statementCache, isolationLevel, this.configuration.isForceBinary()))
+                    .map(isolationLevel -> new PostgresqlConnection(client, codecs, DefaultPortalNameSupplier.INSTANCE, statementCache, isolationLevel, this.configuration))
                     .delayUntil(connection -> {
                         return prepareConnection(connection, client.getByteBufAllocator(), codecs);
                     })

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -53,6 +53,11 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
     public static final Option<Boolean> AUTODETECT_EXTENSIONS = Option.valueOf("autodetectExtensions");
 
     /**
+     * Fetch Size.
+     */
+    public static final Option<Integer> FETCH_SIZE = Option.valueOf("fetchSize");
+
+    /**
      * Force binary transfer.
      */
     public static final Option<Boolean> FORCE_BINARY = Option.valueOf("forceBinary");
@@ -258,6 +263,11 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
         Integer port = connectionFactoryOptions.getValue(PORT);
         if (port != null) {
             builder.port(port);
+        }
+
+        Integer fetchSize = connectionFactoryOptions.getValue(FETCH_SIZE);
+        if (fetchSize != null) {
+            builder.fetchSize(fetchSize);
         }
 
         Object forceBinary = connectionFactoryOptions.getValue(FORCE_BINARY);

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -265,9 +265,9 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
             builder.port(port);
         }
 
-        Integer fetchSize = connectionFactoryOptions.getValue(FETCH_SIZE);
+        Object fetchSize = connectionFactoryOptions.getValue(FETCH_SIZE);
         if (fetchSize != null) {
-            builder.fetchSize(fetchSize);
+            builder.fetchSize(convertToInt(fetchSize));
         }
 
         Object forceBinary = connectionFactoryOptions.getValue(FORCE_BINARY);

--- a/src/main/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatement.java
+++ b/src/main/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatement.java
@@ -56,6 +56,7 @@ final class SimpleQueryPostgresqlStatement implements PostgresqlStatement {
     SimpleQueryPostgresqlStatement(ConnectionContext context, String sql) {
         this.context = Assert.requireNonNull(context, "context must not be null");
         this.sql = Assert.requireNonNull(sql, "sql must not be null");
+        fetchSize(this.context.getConfiguration().getFetchSize());
     }
 
     @Override

--- a/src/main/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatement.java
+++ b/src/main/java/io/r2dbc/postgresql/SimpleQueryPostgresqlStatement.java
@@ -56,7 +56,7 @@ final class SimpleQueryPostgresqlStatement implements PostgresqlStatement {
     SimpleQueryPostgresqlStatement(ConnectionContext context, String sql) {
         this.context = Assert.requireNonNull(context, "context must not be null");
         this.sql = Assert.requireNonNull(sql, "sql must not be null");
-        fetchSize(this.context.getConfiguration().getFetchSize());
+        fetchSize(this.context.getConfiguration().getFetchSize(sql));
     }
 
     @Override

--- a/src/test/java/io/r2dbc/postgresql/FetchSizeIntegrationTests.java
+++ b/src/test/java/io/r2dbc/postgresql/FetchSizeIntegrationTests.java
@@ -29,6 +29,22 @@ public class FetchSizeIntegrationTests extends AbstractIntegrationTests {
         System.gc();
     }
 
+    @Override
+    protected void customize(PostgresqlConnectionConfiguration.Builder builder) {
+        builder.fetchSize(100);
+    }
+
+    @Test
+    void exchangeWithDefaultFetchSize() {
+        this.connection.createStatement("SELECT * FROM generate_series(1,20) WHERE $1 = $1")
+                .bind(0, 1)
+                .execute()
+                .flatMap(r -> r.map((row, meta) -> row.get(0, Integer.class)))
+                .as(StepVerifier::create)
+                .expectNextCount(20)
+                .verifyComplete();
+    }
+
     @Test
     void exchangeWithFetchSize() {
         this.connection.createStatement("SELECT * FROM generate_series(1,20) WHERE $1 = $1")

--- a/src/test/java/io/r2dbc/postgresql/MockContext.java
+++ b/src/test/java/io/r2dbc/postgresql/MockContext.java
@@ -53,7 +53,13 @@ final class MockContext {
         }
 
         public ConnectionContext build() {
-            return new ConnectionContext(this.client, this.codecs, this.connection, forceBinary, portalNameSupplier, statementCache);
+            PostgresqlConnectionConfiguration configuration = PostgresqlConnectionConfiguration.builder()
+                    .host("localhost")
+                    .username("admin")
+                    .password("password")
+                    .forceBinary(forceBinary)
+                    .build();
+            return new ConnectionContext(this.client, this.codecs, this.connection, configuration, portalNameSupplier, statementCache);
         }
 
         public Builder codecs(Codecs codecs) {

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionConfigurationTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionConfigurationTest.java
@@ -53,6 +53,11 @@ final class PostgresqlConnectionConfigurationTest {
     }
 
     @Test
+    void builderNegativeFetchSize() {
+        assertThatIllegalArgumentException().isThrownBy(() -> PostgresqlConnectionConfiguration.builder().fetchSize(-1))
+            .withMessage("fetch size must be greater or equal zero");
+    }
+    @Test
     void configuration() {
         Map<String, String> options = new HashMap<>();
         options.put("lock_timeout", "10s");

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
@@ -163,7 +163,7 @@ final class PostgresqlConnectionFactoryProviderTest {
                 .option(FETCH_SIZE, 100)
                 .build());
 
-        assertThat(factory.getConfiguration().getFetchSize()).isEqualTo(100);
+        assertThat(factory.getConfiguration().getFetchSize().applyAsInt("")).isEqualTo(100);
     }
 
     @Test
@@ -176,7 +176,7 @@ final class PostgresqlConnectionFactoryProviderTest {
                 .option(Option.valueOf("fetchSize"), "100")
                 .build());
 
-        assertThat(factory.getConfiguration().getFetchSize()).isEqualTo(100);
+        assertThat(factory.getConfiguration().getFetchSize().applyAsInt("")).isEqualTo(100);
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.AUTODETECT_EXTENSIONS;
+import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.FETCH_SIZE;
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.FORCE_BINARY;
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.LEGACY_POSTGRESQL_DRIVER;
 import static io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider.OPTIONS;
@@ -150,6 +151,19 @@ final class PostgresqlConnectionFactoryProviderTest {
             .option(HOST, "test-host")
             .option(USER, "test-user")
             .build())).isNotNull();
+    }
+
+    @Test
+    void providerShouldConsiderFetchSize() {
+        PostgresqlConnectionFactory factory = this.provider.create(builder()
+                .option(DRIVER, LEGACY_POSTGRESQL_DRIVER)
+                .option(HOST, "test-host")
+                .option(PASSWORD, "test-password")
+                .option(USER, "test-user")
+                .option(FETCH_SIZE, 100)
+                .build());
+
+        assertThat(factory.getConfiguration().getFetchSize()).isEqualTo(100);
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
@@ -167,6 +167,19 @@ final class PostgresqlConnectionFactoryProviderTest {
     }
 
     @Test
+    void providerShouldConsiderFetchSizeAsString() {
+        PostgresqlConnectionFactory factory = this.provider.create(builder()
+                .option(DRIVER, LEGACY_POSTGRESQL_DRIVER)
+                .option(HOST, "test-host")
+                .option(PASSWORD, "test-password")
+                .option(USER, "test-user")
+                .option(Option.valueOf("fetchSize"), "100")
+                .build());
+
+        assertThat(factory.getConfiguration().getFetchSize()).isEqualTo(100);
+    }
+
+    @Test
     void providerShouldConsiderBinaryTransfer() {
         PostgresqlConnectionFactory factory = this.provider.create(builder()
             .option(DRIVER, LEGACY_POSTGRESQL_DRIVER)

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionTest.java
@@ -150,7 +150,7 @@ final class PostgresqlConnectionTest {
 
     @Test
     void constructorNoPortalNameSupplier() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlConnection(NO_OP, MockCodecs.empty(), null, this.statementCache, IsolationLevel.READ_COMMITTED, false))
+        assertThatIllegalArgumentException().isThrownBy(() -> new PostgresqlConnection(NO_OP, MockCodecs.empty(), null, this.statementCache, IsolationLevel.READ_COMMITTED, null))
             .withMessage("portalNameSupplier must not be null");
     }
 
@@ -473,6 +473,11 @@ final class PostgresqlConnectionTest {
     }
 
     private PostgresqlConnection createConnection(Client client, MockCodecs codecs, StatementCache cache) {
-        return new PostgresqlConnection(client, codecs, () -> "", cache, IsolationLevel.READ_COMMITTED, false);
+        PostgresqlConnectionConfiguration configuration = PostgresqlConnectionConfiguration.builder()
+                .host("127.0.0.1")
+                .username("admin")
+                .password("password")
+                .build();
+        return new PostgresqlConnection(client, codecs, () -> "", cache, IsolationLevel.READ_COMMITTED, configuration);
     }
 }


### PR DESCRIPTION
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/master/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

Fixes #256
 
#### New Public APIs

- `PostgresqlConnectionConfiguration.builder().fetchSize()`
- `PostgresqlConnectionFactoryProvider.FETCH_SIZE`

#### Additional context

- Refactored some classes to pass and store `PostgresqlConnectionConfiguration` instead of duplicating the fetch size and forceBinary fields. Should make it more future proof to future additions
- I probably need more tests, but not sure where or what I should add so some guidance would be good here.
