### PR TITLE
Add codec for hstore as Map (text and binary decode)

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
@@ -27,6 +27,7 @@ import io.r2dbc.postgresql.client.SSLConfig;
 import io.r2dbc.postgresql.client.SSLMode;
 import io.r2dbc.postgresql.client.StartupMessageFlow;
 import io.r2dbc.postgresql.codec.DefaultCodecs;
+import io.r2dbc.postgresql.codec.DynamicCodecs;
 import io.r2dbc.postgresql.extension.CodecRegistrar;
 import io.r2dbc.postgresql.message.backend.AuthenticationMessage;
 import io.r2dbc.postgresql.util.Assert;
@@ -202,6 +203,8 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
 
         List<Publisher<?>> publishers = new ArrayList<>();
         publishers.add(setSchema(connection));
+
+        publishers.add(new DynamicCodecs().register(connection, byteBufAllocator, codecs));
 
         this.extensions.forEach(CodecRegistrar.class, it -> {
             publishers.add(it.register(connection, byteBufAllocator, codecs));

--- a/src/main/java/io/r2dbc/postgresql/codec/DynamicCodecs.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/DynamicCodecs.java
@@ -1,0 +1,53 @@
+package io.r2dbc.postgresql.codec;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.r2dbc.postgresql.api.PostgresqlConnection;
+import io.r2dbc.postgresql.extension.CodecRegistrar;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DynamicCodecs implements CodecRegistrar {
+
+    private enum AvailableCodecs {
+        HSTORE("hstore");
+        private final String name;
+
+        AvailableCodecs(String name) {
+            this.name = name;
+        }
+
+        public Codec<?> createCodec(ByteBufAllocator byteBufAllocator, int oid) {
+            switch (this) {
+                case HSTORE:
+                    return new HStoreCodec(byteBufAllocator, oid);
+                default:
+                    return null;
+            }
+        }
+    }
+
+    @Override
+    public Publisher<Void> register(PostgresqlConnection connection, ByteBufAllocator byteBufAllocator, CodecRegistry registry) {
+        List<Publisher<Void>> publishers = new ArrayList<>();
+        for (AvailableCodecs availableCodecs : AvailableCodecs.values()) {
+            publishers.add(
+                connection.createStatement("SELECT oid FROM pg_catalog.pg_type WHERE typname = $1")
+                    .bind("$1", availableCodecs.name)
+                    .execute()
+                    .flatMap(it -> it.map((row, rowMetadata) -> {
+                            Integer oid = row.get("oid", Integer.class);
+                            if (oid != null) {
+                                registry.addLast(availableCodecs.createCodec(byteBufAllocator, oid));
+                            }
+                            return Mono.empty();
+                        })
+                    ).then()
+            );
+        }
+        return Flux.concat(publishers);
+    }
+}

--- a/src/main/java/io/r2dbc/postgresql/codec/HStoreCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/HStoreCodec.java
@@ -28,6 +28,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.netty.util.CharsetUtil.UTF_8;
 import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
 
 @SuppressWarnings("rawtypes")
@@ -156,15 +157,17 @@ final class HStoreCodec implements Codec<Map> {
 
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 String k = entry.getKey().toString();
-                buffer.writeInt(k.length());
-                buffer.writeCharSequence(k, Charset.defaultCharset());
+                byte[] bytes = k.getBytes(UTF_8);
+                buffer.writeInt(bytes.length);
+                buffer.writeBytes(bytes);
 
                 if (entry.getValue() == null) {
                     buffer.writeInt(-1);
                 } else {
                     String v = entry.getValue().toString();
-                    buffer.writeInt(v.length());
-                    buffer.writeCharSequence(v, Charset.defaultCharset());
+                    bytes = v.getBytes(UTF_8);
+                    buffer.writeInt(bytes.length);
+                    buffer.writeBytes(bytes);
                 }
             }
             return buffer;

--- a/src/main/java/io/r2dbc/postgresql/codec/HStoreCodec.java
+++ b/src/main/java/io/r2dbc/postgresql/codec/HStoreCodec.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.message.Format;
+import io.r2dbc.postgresql.util.Assert;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.Nullable;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
+
+@SuppressWarnings("rawtypes")
+final class HStoreCodec implements Codec<Map> {
+
+    private final ByteBufAllocator byteBufAllocator;
+    private final Class<Map> type = Map.class;
+    private final int oid;
+
+    /**
+     * Creates a new {@link HStoreCodec}.
+     *
+     * @param byteBufAllocator the type handled by this codec
+     */
+    HStoreCodec(ByteBufAllocator byteBufAllocator, int oid) {
+        this.byteBufAllocator = Assert.requireNonNull(byteBufAllocator, "byteBufAllocator must not be null");
+        this.oid = oid;
+    }
+
+    @Override
+    public boolean canDecode(int dataType, Format format, Class<?> type) {
+        Assert.requireNonNull(format, "format must not be null");
+        Assert.requireNonNull(type, "type must not be null");
+
+        return dataType == oid && isTypeAssignable(type);
+    }
+
+    @Override
+    public boolean canEncode(Object value) {
+        Assert.requireNonNull(value, "value must not be null");
+
+        return this.type.isInstance(value);
+    }
+
+    @Override
+    public boolean canEncodeNull(Class<?> type) {
+        Assert.requireNonNull(type, "type must not be null");
+
+        return this.type.isAssignableFrom(type);
+    }
+
+    @Override
+    public Map<String, String> decode(@Nullable ByteBuf buffer, int dataType, Format format, Class<? extends Map> type) {
+        if (buffer == null) {
+            return null;
+        } else if (format == Format.FORMAT_TEXT) {
+            return doTextDecode(buffer);
+        }
+        return doBinaryDecode(buffer);
+    }
+
+    private Map<String, String> doBinaryDecode(ByteBuf buffer) {
+        Map<String, String> m = new HashMap<>();
+        int pos = 0;
+        int numElements = buffer.getInt(pos);
+        pos += 4;
+
+        for (int i = 0; i < numElements; ++i) {
+            int keyLen = buffer.getInt(pos);
+            pos += 4;
+            String key = buffer.getCharSequence(pos, keyLen, Charset.defaultCharset()).toString();
+            pos += keyLen;
+            int valLen = buffer.getInt(pos);
+            pos += 4;
+            String val;
+            if (valLen == -1) {
+                val = null;
+            } else {
+                val = buffer.getCharSequence(pos, valLen, Charset.defaultCharset()).toString();
+                pos += valLen;
+            }
+            m.put(key, val);
+        }
+        return m;
+    }
+
+    private Map<String, String> doTextDecode(ByteBuf buffer) {
+        Map<String, String> map = new HashMap<>();
+        int pos = 0;
+        int size = buffer.readableBytes();
+        StringBuilder sb = new StringBuilder();
+
+        while (pos < size) {
+            pos = setString(sb, buffer, pos, size) + 3; // append '=>'
+            String key = sb.toString();
+            String value;
+
+            if ((char) buffer.getByte(pos) == 'N') {
+                value = null;
+                pos += 4; // append 'NULL'
+            } else {
+                pos = setString(sb, buffer, pos, size) + 1;
+                value = sb.toString();
+            }
+            map.put(key, value);
+        }
+        return map;
+    }
+
+    private int setString(StringBuilder sb, ByteBuf buffer, int pos, int size) {
+        sb.setLength(0);
+        while (pos < size && buffer.getByte(pos) != '"') {
+            pos++;
+        }
+        for (pos += 1; pos < size; pos++) {
+            char c = (char) buffer.getByte(pos);
+            if (c == '"') {
+                break;
+            } else if (c == '\\') {
+                pos++;
+                c = (char) buffer.getByte(pos);
+            }
+            sb.append(c);
+        }
+        return pos;
+    }
+
+    @Override
+    public Parameter encode(Object value) {
+        Assert.requireNonNull(value, "value must not be null");
+        Map<?, ?> map = (Map<?, ?>) value;
+
+        return new Parameter(Format.FORMAT_BINARY, oid, Mono.fromSupplier(() -> {
+            ByteBuf buffer = byteBufAllocator.buffer(4 + 10 * map.size());
+            buffer.writeInt(map.size());
+
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                String k = entry.getKey().toString();
+                buffer.writeInt(k.length());
+                buffer.writeCharSequence(k, Charset.defaultCharset());
+
+                if (entry.getValue() == null) {
+                    buffer.writeInt(-1);
+                } else {
+                    String v = entry.getValue().toString();
+                    buffer.writeInt(v.length());
+                    buffer.writeCharSequence(v, Charset.defaultCharset());
+                }
+            }
+            return buffer;
+        }));
+    }
+
+    @Override
+    public Parameter encodeNull() {
+        return new Parameter(Format.FORMAT_BINARY, oid, NULL_VALUE);
+    }
+
+    @Override
+    public Class<?> type() {
+        return type;
+    }
+
+    boolean isTypeAssignable(Class<?> type) {
+        Assert.requireNonNull(type, "type must not be null");
+
+        return type.isAssignableFrom(this.type);
+    }
+}

--- a/src/test/java/io/r2dbc/postgresql/codec/HStoreCodecTest.java
+++ b/src/test/java/io/r2dbc/postgresql/codec/HStoreCodecTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.postgresql.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.postgresql.client.Parameter;
+import io.r2dbc.postgresql.client.ParameterAssert;
+import io.r2dbc.postgresql.message.Format;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.r2dbc.postgresql.client.Parameter.NULL_VALUE;
+import static io.r2dbc.postgresql.message.Format.FORMAT_BINARY;
+import static io.r2dbc.postgresql.message.Format.FORMAT_TEXT;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSON;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.JSONB;
+import static io.r2dbc.postgresql.type.PostgresqlObjectId.VARCHAR;
+import static io.r2dbc.postgresql.util.TestByteBufAllocator.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+final class HStoreCodecTest {
+
+    private static final int dataType = 20832;
+
+    @Test
+    void constructorNoByteBufAllocator() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new HStoreCodec(null, dataType))
+            .withMessage("byteBufAllocator must not be null");
+    }
+
+    @Test
+    void decodeAsText() {
+        ByteBuf buffer = TEST.buffer();
+        buffer.writeCharSequence("\"b\"=>\"\\\"2.2\", \"a\\\"\"=>\"1\", \"c\"=>NULL", Charset.defaultCharset());
+        Map<String, String> res = new HStoreCodec(TEST, dataType).decode(buffer, dataType, Format.FORMAT_TEXT, Map.class);
+        Map<String, String> expect = new HashMap<>();
+        expect.put("a\"", "1");
+        expect.put("b", "\"2.2");
+        expect.put("c", null);
+
+        Assertions.assertThat(res).isEqualTo(expect);
+    }
+
+    @Test
+    void decode() {
+        assertThat(new HStoreCodec(TEST, dataType).decode(TEST.buffer(), dataType, FORMAT_BINARY, Map.class))
+            .isEqualTo(new HashMap<String, String>());
+    }
+
+    @Test
+    void decodeNoByteBuf() {
+        assertThat(new HStoreCodec(TEST, dataType).decode(null, dataType, FORMAT_TEXT, Map.class)).isNull();
+    }
+
+    @Test
+    void canDecode() {
+        HStoreCodec codec = new HStoreCodec(TEST, dataType);
+
+        assertThat(codec.canDecode(dataType, FORMAT_TEXT, Map.class)).isTrue();
+        assertThat(codec.canDecode(dataType, FORMAT_BINARY, Map.class)).isTrue();
+        assertThat(codec.canDecode(VARCHAR.getObjectId(), FORMAT_BINARY, Map.class)).isFalse();
+        assertThat(codec.canDecode(JSON.getObjectId(), FORMAT_TEXT, Map.class)).isFalse();
+        assertThat(codec.canDecode(JSONB.getObjectId(), FORMAT_BINARY, Map.class)).isFalse();
+    }
+
+    @Test
+    void canDecodeNoFormat() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new HStoreCodec(TEST, dataType).canDecode(dataType, null, Map.class))
+            .withMessage("format must not be null");
+    }
+
+    @Test
+    void canDecodeNoClass() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new HStoreCodec(TEST, dataType).canDecode(dataType, FORMAT_TEXT, null))
+            .withMessage("type must not be null");
+    }
+
+    @Test
+    void encode() {
+        ByteBuf buffer = TEST.buffer(4);
+        buffer.writeInt(0);
+        ParameterAssert.assertThat(new HStoreCodec(TEST, dataType).encode(new HashMap<>()))
+            .hasFormat(FORMAT_BINARY)
+            .hasType(dataType)
+            .hasValue(buffer);
+    }
+
+    @Test
+    void encodeNoValue() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new HStoreCodec(TEST, dataType).encode(null))
+            .withMessage("value must not be null");
+    }
+
+    @Test
+    void encodeNull() {
+        assertThat(new HStoreCodec(TEST, dataType).encodeNull())
+            .isEqualTo(new Parameter(FORMAT_BINARY, dataType, NULL_VALUE));
+    }
+
+}


### PR DESCRIPTION
#### Issue description

GitHub issue #268

#### Additional context

`hstore` OID is dynamics, I should add a test at connection with this query:
```sql
SELECT oid FROM pg_catalog.pg_type WHERE typname = 'hstore';
```

Closes #268