### PR TITLE
use "schema" as "search_path" connection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | `forceBinary`     | Whether to force binary transfer.  Defaults to `false`. _(Optional)_
 | `preparedStatementCacheQueries` | Determine the number of queries that are cached in each connection. The default is `-1`, meaning there's no limit. The value of `0` disables the cache. Any other value specifies the cache size.
 | `options`         | A `Map<String, String>` of connection parameters. These are applied to each database connection created by the `ConnectionFactory`. Useful for setting generic [PostgreSQL connection parameters][psql-runtime-config]. _(Optional)_
-| `schema`          | The schema to set. _(Optional)_
+| `schema`          | The search path to set. _(Optional)_
 | `sslMode`         | SSL mode to use, see `SSLMode` enum. Supported values: `DISABLE`, `ALLOW`, `PREFER`, `REQUIRE`, `VERIFY_CA`, `VERIFY_FULL`. _(Optional)_
 | `sslRootCert`     | Path to SSL CA certificate in PEM format. _(Optional)_
 | `sslKey`          | Path to SSL key for TLS authentication in PEM format. _(Optional)_

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionConfiguration.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -74,8 +75,6 @@ public final class PostgresqlConnectionConfiguration {
 
     private final int port;
 
-    private final String schema;
-
     private final String socket;
 
     private final String username;
@@ -97,14 +96,28 @@ public final class PostgresqlConnectionConfiguration {
         this.fetchSize = fetchSize;
         this.forceBinary = forceBinary;
         this.host = host;
-        this.options = options;
+        this.options = initOptions(options);
         this.password = password;
         this.port = port;
-        this.schema = schema;
+        addToOptions(schema);
         this.socket = socket;
         this.username = Assert.requireNonNull(username, "username must not be null");
         this.sslConfig = sslConfig;
         this.preparedStatementCacheQueries = preparedStatementCacheQueries;
+    }
+
+    private Map<String, String> initOptions(@Nullable Map<String, String> options) {
+        if (options == null) {
+            return new HashMap<>();
+        } else {
+            return options;
+        }
+    }
+
+    private void addToOptions(String schema) {
+        if (schema != null && !schema.isEmpty()) {
+            options.put("search_path", schema);
+        }
     }
 
     /**
@@ -131,7 +144,6 @@ public final class PostgresqlConnectionConfiguration {
             ", options='" + this.options + '\'' +
             ", password='" + obfuscate(this.password != null ? this.password.length() : 0) + '\'' +
             ", port=" + this.port +
-            ", schema='" + this.schema + '\'' +
             ", username='" + this.username + '\'' +
             '}';
     }
@@ -190,11 +202,6 @@ public final class PostgresqlConnectionConfiguration {
 
     int getPort() {
         return this.port;
-    }
-
-    @Nullable
-    String getSchema() {
-        return this.schema;
     }
 
     @Nullable

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactory.java
@@ -201,7 +201,6 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
     private Publisher<?> prepareConnection(PostgresqlConnection connection, ByteBufAllocator byteBufAllocator, DefaultCodecs codecs) {
 
         List<Publisher<?>> publishers = new ArrayList<>();
-        publishers.add(setSchema(connection));
 
         this.extensions.forEach(CodecRegistrar.class, it -> {
             publishers.add(it.register(connection, byteBufAllocator, codecs));
@@ -267,16 +266,6 @@ public final class PostgresqlConnectionFactory implements ConnectionFactory {
 
                 return IsolationLevel.valueOf(level.toUpperCase(Locale.US));
             })).defaultIfEmpty(IsolationLevel.READ_COMMITTED).last();
-    }
-
-    private Mono<Void> setSchema(PostgresqlConnection connection) {
-        if (this.configuration.getSchema() == null) {
-            return Mono.empty();
-        }
-
-        return connection.createStatement(String.format("SET SCHEMA '%s'", this.configuration.getSchema()))
-            .execute()
-            .then();
     }
 
     static class PostgresConnectionException extends R2dbcNonTransientResourceException {

--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -73,9 +73,14 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
     public static final String LEGACY_POSTGRESQL_DRIVER = "postgres";
 
     /**
-     * Schema.
+     * Schema search path (alias for "currentSchema").
      */
     public static final Option<String> SCHEMA = Option.valueOf("schema");
+
+    /**
+     * Schema search path.
+     */
+    public static final Option<String> CURRENT_SCHEMA = Option.valueOf("currentSchema");
 
     /**
      * Unix domain socket.
@@ -247,7 +252,13 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
         builder.connectTimeout(connectionFactoryOptions.getValue(CONNECT_TIMEOUT));
         builder.database(connectionFactoryOptions.getValue(DATABASE));
         builder.password(connectionFactoryOptions.getValue(PASSWORD));
-        builder.schema(connectionFactoryOptions.getValue(SCHEMA));
+
+        if (connectionFactoryOptions.getValue(CURRENT_SCHEMA) != null) {
+            builder.schema(connectionFactoryOptions.getValue(CURRENT_SCHEMA));
+        } else {
+            builder.schema(connectionFactoryOptions.getValue(SCHEMA));
+        }
+
         builder.username(connectionFactoryOptions.getRequiredValue(USER));
 
         String applicationName = connectionFactoryOptions.getValue(APPLICATION_NAME);

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionConfigurationTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionConfigurationTest.java
@@ -80,12 +80,16 @@ final class PostgresqlConnectionConfigurationTest {
             .hasFieldOrPropertyWithValue("connectTimeout", Duration.ofMillis(1000))
             .hasFieldOrPropertyWithValue("database", "test-database")
             .hasFieldOrPropertyWithValue("host", "test-host")
-            .hasFieldOrPropertyWithValue("options", options)
+            .hasFieldOrProperty("options")
             .hasFieldOrPropertyWithValue("password", null)
             .hasFieldOrPropertyWithValue("port", 100)
-            .hasFieldOrPropertyWithValue("schema", "test-schema")
             .hasFieldOrPropertyWithValue("username", "test-username")
             .hasFieldOrProperty("sslConfig");
+
+        assertThat(configuration.getOptions())
+                .containsEntry("lock_timeout", "10s")
+                .containsEntry("statement_timeout", "60000")
+                .containsEntry("search_path", "test-schema");
     }
 
     @Test
@@ -104,9 +108,12 @@ final class PostgresqlConnectionConfigurationTest {
             .hasFieldOrPropertyWithValue("host", "test-host")
             .hasFieldOrPropertyWithValue("password", "test-password")
             .hasFieldOrPropertyWithValue("port", 5432)
-            .hasFieldOrPropertyWithValue("schema", "test-schema")
+            .hasFieldOrProperty("options")
             .hasFieldOrPropertyWithValue("username", "test-username")
             .hasFieldOrProperty("sslConfig");
+
+        assertThat(configuration.getOptions())
+                .containsEntry("search_path", "test-schema");
     }
 
     @Test

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryTest.java
@@ -63,7 +63,7 @@ final class PostgresqlConnectionFactoryTest {
         // @formatter:off
         Client client = TestClient.builder()
             .window()
-                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", null)).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
+                .expectRequest(new StartupMessage("test-application-name", "test-database", "test-username", Collections.emptyMap())).thenRespond(new AuthenticationMD5Password(TEST.buffer(4).writeInt(100)))
                 .expectRequest(new PasswordMessage("md55e9836cdb369d50e3bc7d127e88b4804")).thenRespond(AuthenticationOk.INSTANCE)
                 .done()
             .build();


### PR DESCRIPTION
This change adds an alias `currentSchema` for `schema` configuration parameter; and uses this value as a value for "search_path" connection option (instead of executing `SET SCHEMA TO` command upon connection)

[resolves #271 ]

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/master/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
Closes #271 

#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
