### PR TITLE
adds capability to specify connections options via URL

### DIFF
--- a/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProvider.java
@@ -320,13 +320,12 @@ public final class PostgresqlConnectionFactoryProvider implements ConnectionFact
             builder.preparedStatementCacheQueries(convertToInt(preparedStatementCacheQueries));
         }
 
-        Map<String, String> options;
-        try {
-            options = connectionFactoryOptions.getValue(OPTIONS);
-        } catch (ClassCastException exception) {
-            Option<String> optionsAsString = Option.valueOf("options");
-            options = mapOptionsFromUrlString(connectionFactoryOptions.getValue(optionsAsString));
-        }
+        Option<Object> optionsAsObject = Option.valueOf("options");
+        Object optionsObject = connectionFactoryOptions.getValue(optionsAsObject);
+
+        Map<String, String> options = optionsObject instanceof String
+            ? mapOptionsFromUrlString((String) optionsObject)
+            : connectionFactoryOptions.getValue(OPTIONS);
 
         if (options != null) {
             builder.options(options);

--- a/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/postgresql/PostgresqlConnectionFactoryProviderTest.java
@@ -23,6 +23,7 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -321,4 +322,38 @@ final class PostgresqlConnectionFactoryProviderTest {
         assertThat(factory.getConfiguration().getRequiredSocket()).isEqualTo("/tmp/.s.PGSQL.5432");
     }
 
+    @Test
+    void shouldParseOptionsProvidedAsString() {
+        final Option<String> options = Option.valueOf("options");
+        PostgresqlConnectionFactory factory = this.provider.create(builder()
+            .option(DRIVER, POSTGRESQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(PASSWORD, "test-password")
+            .option(USER, "test-user")
+            .option(options, "search_path=public,private;default_tablespace=unknown")
+            .build());
+
+        assertThat(factory.getConfiguration().getOptions().get("search_path")).isEqualTo("public,private");
+        assertThat(factory.getConfiguration().getOptions().get("default_tablespace")).isEqualTo("unknown");
+    }
+
+    @Test
+    void shouldParseOptionsProvidedAsMap() {
+        final Option<Map<String, String>> options = Option.valueOf("options");
+
+        Map<String, String> optionsMap = new HashMap<>();
+        optionsMap.put("search_path", "public,private");
+        optionsMap.put("default_tablespace", "unknown");
+
+        PostgresqlConnectionFactory factory = this.provider.create(builder()
+            .option(DRIVER, POSTGRESQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(PASSWORD, "test-password")
+            .option(USER, "test-user")
+            .option(options, optionsMap)
+            .build());
+
+        assertThat(factory.getConfiguration().getOptions().get("search_path")).isEqualTo("public,private");
+        assertThat(factory.getConfiguration().getOptions().get("default_tablespace")).isEqualTo("unknown");
+    }
 }


### PR DESCRIPTION
added workaround for cases when "options" have been provided via URL and are represented with a String, not a Map)

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/master/CONTRIBUTING.adoc).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/master/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

Resolves #271 
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
